### PR TITLE
feat: restore shutter angle and the lost sheet follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+
+- Calculated shutter angle (5.6°–360°) on the SHUTTER sheet. The camera still
+  takes 1/N; we convert from the live frame rate.
+- Shared Swift protocol core for DJI Osmo Pocket: DUML framing, BLE discovery, SoftAP join, and
+  HEVC/AVC live-view depacketizing.
+- iOS SwiftUI shell with saved cameras, live monitor chrome, and GPU assists (LUT import, peaking,
+  zebra, false color, waveform, histogram, guides).
+- Android Jetpack Compose shell in `Apps/Android/` consuming the same Swift core over JNI.
+- Public repository hygiene: `just check`, secret scan, landing page at openpocketcine.app.
+
 ### Changed
 
 - Replace the app mark across iOS, Android, and the landing page with the
@@ -15,11 +26,9 @@ All notable changes to this project are documented here. The format is based on
 - Rewrite public protocol and capture docs so intercept cookbooks stay out of the
   tracked tree.
 
-### Added
+### Fixed
 
-- Shared Swift protocol core for DJI Osmo Pocket: DUML framing, BLE discovery, SoftAP join, and
-  HEVC/AVC live-view depacketizing.
-- iOS SwiftUI shell with saved cameras, live monitor chrome, and GPU assists (LUT import, peaking,
-  zebra, false color, waveform, histogram, guides).
-- Android Jetpack Compose shell in `Apps/Android/` consuming the same Swift core over JNI.
-- Public repository hygiene: `just check`, secret scan, landing page at openpocketcine.app.
+- LUT 50/50 stays pinned when the catalog scrolls, so landscape no longer hides
+  it.
+- AUDIO Channel, Wind, Dir, and Vocal stay on the value you pick instead of
+  bouncing back to the previous DSP snapshot.

--- a/Sources/OpenPocketCineAndroidFacade/AndroidSessionWire.swift
+++ b/Sources/OpenPocketCineAndroidFacade/AndroidSessionWire.swift
@@ -192,9 +192,13 @@ public enum AndroidSessionWire {
         }
         if let hex = str("audioDspBlob"), let bytes = hexBytes(hex), bytes.count == AudioDspBlob.size {
             status.audioDspBlob = bytes
-            status.audioDspAt2 = AudioDspBlob.at2(bytes)
+            if bytes.count > 2 {
+                AudioDspBlob.applyByte2(bytes[2], to: &status)
+            } else {
+                status.audioDspAt2 = AudioDspBlob.at2(bytes)
+            }
         } else if let at2 = optionalUInt8(int("audioDspAt2", default: -1)) {
-            status.audioDspAt2 = AudioDspAt2(raw: at2)
+            AudioDspBlob.applyByte2(at2, to: &status)
         }
         let zoomRaw = int("zoomFactorRaw", default: 0)
         if zoomRaw > 0 { status.zoomFactorRaw = UInt32(clamping: zoomRaw) }

--- a/Sources/OpenPocketViewCore/CameraControl.swift
+++ b/Sources/OpenPocketViewCore/CameraControl.swift
@@ -652,8 +652,8 @@ public struct WhiteBalance: Equatable, Sendable {
 
 /// `0x02/0x8E` pid `0x0020`. Stereo `02`, Mono `01`, Spatial `03`.
 public enum AudioChannel: UInt8, CaseIterable, Sendable {
-    case mono = 0x01
     case stereo = 0x02
+    case mono = 0x01
     case spatial = 0x03
 
     public var label: String {
@@ -747,8 +747,18 @@ public enum AudioDspBlob {
         return out
     }
 
+    /// Captured directional bytes already have the wind-on bit. Keep that
+    /// stop when turning wind on so the Directional tab stays honest.
     public static func patchWind(_ blob: [UInt8], _ value: WindNoiseReduction) -> [UInt8] {
-        patch(blob, byte2: value.rawValue)
+        switch value {
+        case .off:
+            return patch(blob, byte2: WindNoiseReduction.off.rawValue)
+        case .on:
+            if let dir = directional(from: blob.count > 2 ? blob[2] : 0) {
+                return patch(blob, byte2: dir.rawValue)
+            }
+            return patch(blob, byte2: WindNoiseReduction.on.rawValue)
+        }
     }
 
     public static func patchDirectional(_ blob: [UInt8], _ value: DirectionalAudio) -> [UInt8] {
@@ -758,6 +768,31 @@ public enum AudioDspBlob {
     public static func at2(_ blob: [UInt8]) -> AudioDspAt2? {
         guard blob.count > 2 else { return nil }
         return AudioDspAt2(raw: blob[2])
+    }
+
+    /// Wind off is only `18`. Every captured directional byte includes wind-on.
+    public static func wind(from raw: UInt8) -> WindNoiseReduction? {
+        switch raw {
+        case WindNoiseReduction.off.rawValue:
+            return .off
+        case WindNoiseReduction.on.rawValue,
+            DirectionalAudio.all.rawValue,
+            DirectionalAudio.front.rawValue,
+            DirectionalAudio.frontAndBack.rawValue:
+            return .on
+        default:
+            return nil
+        }
+    }
+
+    public static func directional(from raw: UInt8) -> DirectionalAudio? {
+        DirectionalAudio(rawValue: raw)
+    }
+
+    public static func applyByte2(_ raw: UInt8, to status: inout CameraStatus) {
+        status.audioDspAt2 = AudioDspAt2(raw: raw)
+        if let wind = wind(from: raw) { status.windNR = wind }
+        if let dir = directional(from: raw) { status.directionalAudio = dir }
     }
 }
 

--- a/Sources/OpenPocketViewCore/CameraStatus.swift
+++ b/Sources/OpenPocketViewCore/CameraStatus.swift
@@ -89,6 +89,10 @@ public struct CameraStatus: Equatable, Sendable {
     public var audioDspBlob: [UInt8]?
     /// Interpreted audio-DSP blob `@2`.
     public var audioDspAt2: AudioDspAt2?
+    /// Wind NR from DSP `@2`. Survives a directional byte (those include wind-on).
+    public var windNR: WindNoiseReduction?
+    /// Directional audio from DSP `@2`. Kept when `@2` is a wind-only byte.
+    public var directionalAudio: DirectionalAudio?
     /// Live VU / peak from subscribe `cam_audio_status_v2`. Camera-held; no local decay.
     public var audioMeters: AudioMeterLevels = .silent
     /// Last raw `cam_audio_status_v2` value (diagnostics / verify-on-HW).
@@ -219,7 +223,11 @@ public enum CameraStatusDecoder {
         case (0x02, 0xA0):
             if let blob = AudioDspBlob.blob(fromGetReply: p) {
                 status.audioDspBlob = blob
-                status.audioDspAt2 = AudioDspBlob.at2(blob)
+                if blob.count > 2 {
+                    AudioDspBlob.applyByte2(blob[2], to: &status)
+                } else {
+                    status.audioDspAt2 = AudioDspBlob.at2(blob)
+                }
                 return true
             }
             return false

--- a/Sources/OpenPocketViewCore/LiveChromeThrottle.swift
+++ b/Sources/OpenPocketViewCore/LiveChromeThrottle.swift
@@ -34,6 +34,11 @@ public enum LiveChromeThrottle: Sendable {
             || a.focusTrack != b.focusTrack
             || a.whiteBalance != b.whiteBalance
             || a.shootingMode != b.shootingMode
+            || a.audioChannel != b.audioChannel
+            || a.vocalBoost != b.vocalBoost
+            || a.windNR != b.windNR
+            || a.directionalAudio != b.directionalAudio
+            || a.audioDspAt2 != b.audioDspAt2
             || a.availableShutterDenoms != b.availableShutterDenoms
             || a.availableIsoIndices != b.availableIsoIndices
             || a.zoomFactorRaw != b.zoomFactorRaw

--- a/Sources/OpenPocketViewCore/ShutterAngle.swift
+++ b/Sources/OpenPocketViewCore/ShutterAngle.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Operator shutter-angle ladder. The body only accepts 1/N (`setShutter`);
+/// we convert `angle = 360 × fps / denom` locally — no angle opcode.
+///
+/// Stops match OpenZCine's ANGLE tab: 5.6° … 360°.
+public enum ShutterAngle: Sendable {
+    public static let degrees: [Double] = [
+        5.6, 11.2, 22.5, 45, 72, 86.4, 90, 108, 144, 172, 180, 216, 288, 346, 360,
+    ]
+
+    public static let defaultDegrees: Double = 180
+
+    public static let labels: [String] = degrees.map(label)
+
+    /// Integer fps for the conversion. Unknown / out of range falls back to 24.
+    public static func effectiveFps(_ fps: Int) -> Int {
+        (8...240).contains(fps) ? fps : 24
+    }
+
+    public static func label(_ degrees: Double) -> String {
+        if abs(degrees - degrees.rounded()) < 0.05 {
+            return "\(Int(degrees.rounded()))°"
+        }
+        return String(format: "%.1f°", degrees)
+    }
+
+    public static func parse(_ label: String) -> Double? {
+        let trimmed = label.replacingOccurrences(of: "°", with: "")
+            .trimmingCharacters(in: .whitespaces)
+        guard let value = Double(trimmed), value > 0, value <= 360 else { return nil }
+        return value
+    }
+
+    /// 1/N that produces this angle at `fps`. Clamped to the SET range.
+    public static func denom(degrees: Double, fps: Int) -> Int {
+        let angle = max(degrees, 0.1)
+        let rate = Double(effectiveFps(fps))
+        let raw = (360.0 * rate / angle).rounded()
+        return min(max(Int(raw), 1), 16_000)
+    }
+
+    /// Prefer a legal `camcap_shutter` stop when the body has published a list.
+    public static func denom(degrees: Double, fps: Int, available: [Int]) -> Int {
+        let ideal = denom(degrees: degrees, fps: fps)
+        return CamCapShutter.nearestDenom(ideal, in: available) ?? ideal
+    }
+
+    public static func degrees(denom: Int, fps: Int) -> Double {
+        guard denom > 0 else { return defaultDegrees }
+        return 360.0 * Double(effectiveFps(fps)) / Double(denom)
+    }
+
+    public static func nearestDegrees(_ value: Double) -> Double {
+        degrees.min(by: { abs($0 - value) < abs($1 - value) }) ?? defaultDegrees
+    }
+
+    public static func nearestLabel(denom: Int, fps: Int) -> String {
+        label(nearestDegrees(degrees(denom: denom, fps: fps)))
+    }
+}

--- a/Tests/OpenPocketViewCoreTests/LiveChromeThrottleTests.swift
+++ b/Tests/OpenPocketViewCoreTests/LiveChromeThrottleTests.swift
@@ -58,6 +58,21 @@ struct LiveChromeThrottleTests {
         #expect(LiveChromeThrottle.shouldNotify(previous: CameraStatus(), next: next, elapsed: 0))
     }
 
+    @Test func audioOperatorFieldsAreImmediate() {
+        var next = CameraStatus()
+        next.audioChannel = .stereo
+        #expect(LiveChromeThrottle.isImmediate(CameraStatus(), next))
+        next = CameraStatus()
+        next.vocalBoost = .on
+        #expect(LiveChromeThrottle.isImmediate(CameraStatus(), next))
+        next = CameraStatus()
+        next.windNR = .on
+        #expect(LiveChromeThrottle.isImmediate(CameraStatus(), next))
+        next = CameraStatus()
+        next.directionalAudio = .front
+        #expect(LiveChromeThrottle.isImmediate(CameraStatus(), next))
+    }
+
     @Test func shutterCapListIsImmediate() {
         var next = CameraStatus()
         next.availableShutterDenoms = [50, 60, 100]

--- a/Tests/OpenPocketViewCoreTests/MimoControlTests.swift
+++ b/Tests/OpenPocketViewCoreTests/MimoControlTests.swift
@@ -282,9 +282,12 @@ import Testing
         #expect(AudioDspBlob.blob(fromGetReply: reply) == blob)
 
         let windOn = AudioDspBlob.patchWind(blob, .on)
-        #expect(windOn[2] == 0x1A)
+        #expect(windOn[2] == 0xDA)
         #expect(windOn[0] == 0xC0)   // do not rewrite @0
         #expect(Array(windOn[3...]) == Array(blob[3...]))
+        var windBlob = blob
+        windBlob[2] = 0x18
+        #expect(AudioDspBlob.patchWind(windBlob, .on)[2] == 0x1A)
 
         let front = AudioDspBlob.patchDirectional(blob, .front)
         #expect(front[2] == 0x3A)
@@ -302,6 +305,19 @@ import Testing
             to: &s))
         #expect(s.audioDspBlob == blob)
         #expect(s.audioDspAt2 == .directional(.all))
+        #expect(s.windNR == .on)
+        #expect(s.directionalAudio == .all)
+
+        var windOnly = CameraStatus()
+        #expect(CameraStatusDecoder.apply(
+            .init(
+                sender: 0, receiver: 0, seq: 0, flags: 0xC0, cmdSet: 0x02, cmdId: 0xA0,
+                payload: [0x00] + windBlob),
+            to: &windOnly))
+        #expect(windOnly.windNR == .off)
+        #expect(windOnly.directionalAudio == nil)
+        #expect(AudioDspBlob.wind(from: 0x3A) == .on)
+        #expect(AudioDspBlob.directional(from: 0x1A) == nil)
     }
 
     @Test func videoFormatPackAndParse() {

--- a/Tests/OpenPocketViewCoreTests/ShutterAngleTests.swift
+++ b/Tests/OpenPocketViewCoreTests/ShutterAngleTests.swift
@@ -1,0 +1,43 @@
+import Testing
+
+@testable import OpenPocketViewCore
+
+@Suite struct ShutterAngleTests {
+    @Test func ladderRunsFromFivePointSixToThreeSixty() {
+        #expect(ShutterAngle.labels.first == "5.6°")
+        #expect(ShutterAngle.labels.last == "360°")
+        #expect(ShutterAngle.labels.contains("180°"))
+        #expect(ShutterAngle.labels.contains("86.4°"))
+        #expect(ShutterAngle.labels.contains("172°"))
+        #expect(ShutterAngle.parse("180°") == 180)
+        #expect(ShutterAngle.parse("5.6°") == 5.6)
+        #expect(ShutterAngle.label(180) == "180°")
+        #expect(ShutterAngle.label(5.6) == "5.6°")
+        #expect(ShutterAngle.label(11.2) == "11.2°")
+    }
+
+    @Test func oneEightyIsAHalfTurnAtAnyFps() {
+        #expect(ShutterAngle.denom(degrees: 180, fps: 24) == 48)
+        #expect(ShutterAngle.denom(degrees: 180, fps: 25) == 50)
+        #expect(ShutterAngle.denom(degrees: 180, fps: 30) == 60)
+        #expect(ShutterAngle.denom(degrees: 180, fps: 60) == 120)
+        #expect(ShutterAngle.denom(degrees: 360, fps: 24) == 24)
+        #expect(ShutterAngle.denom(degrees: 5.6, fps: 24) == 1_543)
+    }
+
+    @Test func liveSpeedSnapsToTheNearestStop() {
+        #expect(ShutterAngle.nearestLabel(denom: 48, fps: 24) == "180°")
+        #expect(ShutterAngle.nearestLabel(denom: 50, fps: 24) == "172°")
+        #expect(ShutterAngle.nearestLabel(denom: 24, fps: 24) == "360°")
+        #expect(ShutterAngle.nearestLabel(denom: 50, fps: 25) == "180°")
+    }
+
+    @Test func sendSnapsToTheCameraList() {
+        #expect(
+            ShutterAngle.denom(degrees: 180, fps: 24, available: [25, 50, 100, 200])
+                == 50)
+        #expect(ShutterAngle.denom(degrees: 180, fps: 24, available: []) == 48)
+        #expect(ShutterAngle.effectiveFps(0) == 24)
+        #expect(ShutterAngle.effectiveFps(60) == 60)
+    }
+}

--- a/ios/OpenPocketCine/Assists/AssistLongPressChrome.swift
+++ b/ios/OpenPocketCine/Assists/AssistLongPressChrome.swift
@@ -69,6 +69,17 @@ enum AssistLongPressChrome {
             EmptyView()
         }
     }
+
+    /// Controls that must stay on screen when a tall menu scrolls.
+    /// LUT's 50/50 lives here so landscape never hides it under the catalog.
+    @MainActor
+    @ViewBuilder
+    static func footer(for tool: LiveAssistTool, assist: LiveAssistState) -> some View {
+        switch tool {
+        case .lut: LUTAssist.longPressFooter(assist: assist)
+        default: EmptyView()
+        }
+    }
 }
 
 /// Icon frames in `LiveCanvasSpace`, used to park the popup above/below the chip.
@@ -92,7 +103,8 @@ struct AssistIconFrameKey: PreferenceKey {
 }
 
 /// OpenZCine `AssistPanel` shell: 16pt pad, 15pt bold uppercase header, liquid glass.
-struct AssistLongPressPanel<Content: View>: View {
+/// Header and `footer` stay pinned; only `content` scrolls when the well is short.
+struct AssistLongPressPanel<Content: View, Footer: View>: View {
     let tool: LiveAssistTool
     var onClose: () -> Void
     /// Well width from `AssistOptionsPopupAnchor`. Applied before hug/glass so a
@@ -102,7 +114,10 @@ struct AssistLongPressPanel<Content: View>: View {
     /// scrolls only when `shouldScroll` is set by the overlay after measuring.
     var maxHeight: CGFloat? = nil
     var shouldScroll: Bool = false
+    /// When false, `footer` is not laid out so EmptyView cannot add VStack spacing.
+    var showsFooter: Bool = false
     @ViewBuilder var content: Content
+    @ViewBuilder var footer: Footer
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -131,6 +146,9 @@ struct AssistLongPressPanel<Content: View>: View {
             } else {
                 VStack(alignment: .leading, spacing: 0) { content }
             }
+            if showsFooter {
+                footer
+            }
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -140,6 +158,28 @@ struct AssistLongPressPanel<Content: View>: View {
         .liveChromeGlass(in: RoundedRectangle(cornerRadius: DesignTokens.cornerRadius, style: .continuous))
         .contentShape(Rectangle())
         .simultaneousGesture(TapGesture().onEnded {})
+    }
+}
+
+extension AssistLongPressPanel where Footer == EmptyView {
+    init(
+        tool: LiveAssistTool,
+        onClose: @escaping () -> Void,
+        width: CGFloat? = nil,
+        maxHeight: CGFloat? = nil,
+        shouldScroll: Bool = false,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.init(
+            tool: tool,
+            onClose: onClose,
+            width: width,
+            maxHeight: maxHeight,
+            shouldScroll: shouldScroll,
+            showsFooter: false,
+            content: content,
+            footer: { EmptyView() }
+        )
     }
 }
 
@@ -185,9 +225,12 @@ struct AssistLongPressOverlay: View {
             AssistLongPressPanel(
                 tool: tool, onClose: onDismiss, width: place.width,
                 maxHeight: place.maxHeight,
-                shouldScroll: shouldScroll
+                shouldScroll: shouldScroll,
+                showsFooter: tool == .lut
             ) {
                 AssistLongPressChrome.menu(for: tool, assist: assist)
+            } footer: {
+                AssistLongPressChrome.footer(for: tool, assist: assist)
             }
             .id(tool)
             .frame(width: place.width, alignment: .leading)
@@ -213,9 +256,11 @@ struct AssistLongPressOverlay: View {
     private var unconstrainedSizeReader: some View {
         AssistLongPressPanel(
             tool: tool, onClose: {}, width: AssistLongPressChrome.preferredWidth(for: tool),
-            maxHeight: nil, shouldScroll: false
+            maxHeight: nil, shouldScroll: false, showsFooter: tool == .lut
         ) {
             AssistLongPressChrome.menu(for: tool, assist: assist)
+        } footer: {
+            AssistLongPressChrome.footer(for: tool, assist: assist)
         }
         .fixedSize(horizontal: false, vertical: true)
         .background(

--- a/ios/OpenPocketCine/Assists/LUTAssist.swift
+++ b/ios/OpenPocketCine/Assists/LUTAssist.swift
@@ -19,6 +19,12 @@ enum LUTAssist {
     static func longPressMenu(_ assist: LiveAssistState) -> some View {
         LUTPicker(assist: assist, embedded: true)
     }
+
+    /// Pinned under the catalog so landscape never scrolls 50/50 off-screen.
+    @ViewBuilder
+    static func longPressFooter(assist: LiveAssistState) -> some View {
+        LUTSplitComparisonBar(assist: assist)
+    }
 }
 
 /// Official Pocket 4P Rec.709 cubes from the app bundle. Parsed once.

--- a/ios/OpenPocketCine/CameraSession.swift
+++ b/ios/OpenPocketCine/CameraSession.swift
@@ -265,6 +265,7 @@ final class CameraSession {
     /// After a local ISO / shutter / expo SET, ignore subscribe snapshots that have not caught up.
     @ObservationIgnored private var expoPin: ExpoPin?
     @ObservationIgnored private var expoGeneration: UInt64 = 0
+    @ObservationIgnored private var audioPin: AudioPin?
     /// After a local res+fps / color SET, ignore subscribe snapshots that have not caught up.
     @ObservationIgnored private var formatPin: (expected: VideoFormat, deadline: Date)?
     @ObservationIgnored private var colorPin: (expected: ColorMode, deadline: Date)?
@@ -435,6 +436,7 @@ final class CameraSession {
         zoomPinchSlew = nil
         expoPin = nil
         expoGeneration = 0
+        audioPin = nil
         formatPin = nil
         colorPin = nil
         controlBusy = false
@@ -1163,6 +1165,14 @@ final class CameraSession {
         hopNativeISO(from: from, to: .dLog2)
     }
 
+    private struct AudioPin {
+        var channel: AudioChannel?
+        var vocal: VocalBoost?
+        var wind: WindNoiseReduction?
+        var directional: DirectionalAudio?
+        var deadline: Date
+    }
+
     private struct ExpoPin {
         var generation: UInt64
         var iso: Int?
@@ -1218,6 +1228,74 @@ final class CameraSession {
                 return CamFov.matches(live, factor)
             }
         }
+    }
+
+    private func pinAudio(
+        channel: AudioChannel? = nil,
+        vocal: VocalBoost? = nil,
+        wind: WindNoiseReduction? = nil,
+        directional: DirectionalAudio? = nil
+    ) {
+        var pin = audioPin ?? AudioPin(deadline: Date().addingTimeInterval(2))
+        pin.deadline = Date().addingTimeInterval(2)
+        if let channel { pin.channel = channel }
+        if let vocal { pin.vocal = vocal }
+        if let wind { pin.wind = wind }
+        if let directional { pin.directional = directional }
+        audioPin = pin
+    }
+
+    private func audioPinIsEmpty(_ pin: AudioPin) -> Bool {
+        pin.channel == nil && pin.vocal == nil && pin.wind == nil && pin.directional == nil
+    }
+
+    private func clearAudioPin(
+        channel: Bool = false, vocal: Bool = false, wind: Bool = false, directional: Bool = false
+    ) {
+        guard var pin = audioPin else { return }
+        if channel { pin.channel = nil }
+        if vocal { pin.vocal = nil }
+        if wind { pin.wind = nil }
+        if directional { pin.directional = nil }
+        audioPin = audioPinIsEmpty(pin) ? nil : pin
+    }
+
+    /// Drop GET / subscribe snapshots that still show the pre-SET audio row.
+    private func absorbStaleAudio(_ incoming: inout CameraStatus) {
+        guard var pin = audioPin else { return }
+        if Date() >= pin.deadline {
+            audioPin = nil
+            return
+        }
+        if let expect = pin.channel {
+            if incoming.audioChannel == expect {
+                pin.channel = nil
+            } else if incoming.audioChannel != nil {
+                incoming.audioChannel = status.audioChannel
+            }
+        }
+        if let expect = pin.vocal {
+            if incoming.vocalBoost == expect {
+                pin.vocal = nil
+            } else if incoming.vocalBoost != nil {
+                incoming.vocalBoost = status.vocalBoost
+            }
+        }
+        if let expect = pin.wind {
+            if incoming.windNR == expect {
+                pin.wind = nil
+            } else if incoming.windNR != nil {
+                incoming.windNR = status.windNR
+            }
+        }
+        if let expect = pin.directional {
+            if incoming.directionalAudio == expect {
+                pin.directional = nil
+            } else if incoming.directionalAudio != nil {
+                incoming.directionalAudio = status.directionalAudio
+            }
+        }
+        audioPin = audioPinIsEmpty(pin) ? nil : pin
     }
 
     private func pinExpo(
@@ -1441,37 +1519,56 @@ final class CameraSession {
     }
 
     func setAudioChannel(_ channel: AudioChannel) {
+        pinAudio(channel: channel)
         let previous = status.audioChannel
         status.audioChannel = channel
-        fireCamera(
-            Commands.setAudioChannel(channel), name: "Audio \(channel.label)",
-            onFail: { [weak self] in self?.status.audioChannel = previous },
-            onSettle: { [weak self] ok in
-                ControlLiveLog.line(
-                    "audio: channel \(channel.label) ack=\(ok ? "ok" : (self?.controlNote ?? "failed"))")
-            })
+        enqueueAudio {
+            let ok = await self.requestCamera(
+                Commands.setAudioChannel(channel), name: "Audio \(channel.label)")
+            if !ok {
+                if self.status.audioChannel == channel { self.status.audioChannel = previous }
+                self.clearAudioPin(channel: true)
+            }
+            ControlLiveLog.line(
+                "audio: channel \(channel.label) ack=\(ok ? "ok" : (self.controlNote ?? "failed"))")
+        }
     }
 
     func setVocalBoost(_ boost: VocalBoost) {
+        pinAudio(vocal: boost)
         let previous = status.vocalBoost
         status.vocalBoost = boost
-        fireCamera(
-            Commands.setVocalBoost(boost), name: "Vocal \(boost.label)",
-            onFail: { [weak self] in self?.status.vocalBoost = previous },
-            onSettle: { [weak self] ok in
-                ControlLiveLog.line(
-                    "audio: vocal \(boost.label) ack=\(ok ? "ok" : (self?.controlNote ?? "failed"))")
-            })
+        enqueueAudio {
+            let ok = await self.requestCamera(
+                Commands.setVocalBoost(boost), name: "Vocal \(boost.label)")
+            if !ok {
+                if self.status.vocalBoost == boost { self.status.vocalBoost = previous }
+                self.clearAudioPin(vocal: true)
+            }
+            ControlLiveLog.line(
+                "audio: vocal \(boost.label) ack=\(ok ? "ok" : (self.controlNote ?? "failed"))")
+        }
     }
 
     /// GET `0xA0` blob, patch `@2`, SET `0x9F`. Never invent the blob. The GET is
     /// a true round trip, so audio patches ride their own chain — never the SET path.
     func setWindNR(_ value: WindNoiseReduction) {
-        enqueueAudio { await self.patchAudioDsp(name: "Wind \(value.label)") { AudioDspBlob.patchWind($0, value) } }
+        pinAudio(wind: value)
+        status.windNR = value
+        enqueueAudio {
+            await self.patchAudioDsp(name: "Wind \(value.label)") { AudioDspBlob.patchWind($0, value) }
+        }
     }
 
     func setDirectionalAudio(_ value: DirectionalAudio) {
-        enqueueAudio { await self.patchAudioDsp(name: "Dir \(value.label)") { AudioDspBlob.patchDirectional($0, value) } }
+        pinAudio(directional: value)
+        status.directionalAudio = value
+        status.windNR = .on
+        enqueueAudio {
+            await self.patchAudioDsp(name: "Dir \(value.label)") {
+                AudioDspBlob.patchDirectional($0, value)
+            }
+        }
     }
 
     func refreshFocusTrack() async {
@@ -1527,17 +1624,23 @@ final class CameraSession {
         let next = patch(blob)
         let previousBlob = status.audioDspBlob
         let previousAt2 = status.audioDspAt2
+        let previousWind = status.windNR
+        let previousDir = status.directionalAudio
         status.audioDspBlob = next
-        status.audioDspAt2 = AudioDspBlob.at2(next)
-        fireCamera(
-            Commands.audioDspSet(next), name: name,
-            onFail: { [weak self] in
-                self?.status.audioDspBlob = previousBlob
-                self?.status.audioDspAt2 = previousAt2
-            },
-            onSettle: { [weak self] ok in
-                ControlLiveLog.line("audio: \(name) ack=\(ok ? "ok" : (self?.controlNote ?? "failed"))")
-            })
+        if next.count > 2 {
+            AudioDspBlob.applyByte2(next[2], to: &status)
+        } else {
+            status.audioDspAt2 = AudioDspBlob.at2(next)
+        }
+        let ok = await requestCamera(Commands.audioDspSet(next), name: name)
+        if !ok {
+            status.audioDspBlob = previousBlob
+            status.audioDspAt2 = previousAt2
+            status.windNR = previousWind
+            status.directionalAudio = previousDir
+            clearAudioPin(wind: true, directional: true)
+        }
+        ControlLiveLog.line("audio: \(name) ack=\(ok ? "ok" : (controlNote ?? "failed"))")
     }
 
     /// `0x02/0x18` via `Commands.setVideoFormat(resolution:frameRate:)`.
@@ -1561,6 +1664,16 @@ final class CameraSession {
                 self.status.fps = previousFps
                 self.formatPin = nil
             })
+        // Angle mode is ours: keep the chosen degrees and rewrite 1/N for the new fps.
+        if OperatorPrefs.shutterUsesAngle, previousFps != status.fps, status.expoMode != .auto {
+            let denom = ShutterAngle.denom(
+                degrees: OperatorPrefs.shutterAngleDegrees,
+                fps: status.fps,
+                available: status.availableShutterDenoms)
+            if denom != status.shutterDenom {
+                setShutterDenom(denom)
+            }
+        }
     }
 
     var bodyFamily: CameraBodyFamily {
@@ -2299,7 +2412,10 @@ final class CameraSession {
         _ reply: Duml.Frame, name: String, opcode: String, expect: ControlExpect?,
         late: Bool = false, announce: Bool = true
     ) -> Bool {
-        _ = CameraStatusDecoder.apply(reply, to: &status)
+        var next = status
+        _ = CameraStatusDecoder.apply(reply, to: &next)
+        absorbStaleAudio(&next)
+        status = next
         let parsed = CameraReply.parse(reply.payload)
         ControlLiveLog.line(
             "control: got \(name) \(opcode) seq=\(reply.seq) flags=0x\(String(reply.flags, radix: 16)) payload=\(Duml.hex(reply.payload)) success=\(parsed.isSuccess)\(late ? " late-hold" : "")"
@@ -3165,6 +3281,7 @@ final class CameraSession {
         var s = status
         guard CameraStatusDecoder.apply(frame, to: &s) else { return }
         absorbStaleExpo(&s)
+        absorbStaleAudio(&s)
         absorbStaleFormat(&s)
         absorbStaleColor(&s)
         absorbCameraFocus(s)

--- a/ios/OpenPocketCine/CaptureControlSheets.swift
+++ b/ios/OpenPocketCine/CaptureControlSheets.swift
@@ -167,6 +167,10 @@ struct CapturePickerPanel: View {
             guard sheet == .shutter, !isEvSheet else { return }
             reseatShutter()
         }
+        .onChange(of: model.session.status.fps) { _, _ in
+            guard sheet == .shutter, !isEvSheet else { return }
+            reseatShutter()
+        }
         .onChange(of: model.session.status.availableIsoIndices) { _, _ in
             guard sheet == .iso else { return }
             reseatIso()
@@ -174,6 +178,9 @@ struct CapturePickerPanel: View {
         .onChange(of: model.session.status.expoMode) { _, _ in
             guard sheet == .shutter else { return }
             drumSendTask?.cancel()
+            if model.session.status.expoMode != .auto {
+                selectedMode = OperatorPrefs.shutterUsesAngle ? 1 : 0
+            }
             reseatShutterOrEv()
         }
         .onChange(of: model.session.status.colorMode) { _, _ in
@@ -227,6 +234,9 @@ struct CapturePickerPanel: View {
             if isEvSheet {
                 CaptureDrumWheel(options: evLabels, selection: $drumSelection)
                     .id(evLabels)
+            } else if isAngleSheet {
+                CaptureDrumWheel(options: shutterAngleLabels, selection: $drumSelection)
+                    .id(shutterAngleLabels)
             } else {
                 CaptureDrumWheel(options: shutterLabels, selection: $drumSelection)
                     .id(shutterLabels)
@@ -350,13 +360,19 @@ struct CapturePickerPanel: View {
                 }
             }
         case 1:
-            checkedRows(WindNoiseReduction.allCases.map(\.label), selected: windLabel) { label in
+            checkedRows(
+                WindNoiseReduction.allCases.map(\.label),
+                selected: model.session.status.windNR?.label
+            ) { label in
                 if let value = WindNoiseReduction.allCases.first(where: { $0.label == label }) {
                     model.session.setWindNR(value)
                 }
             }
         case 2:
-            checkedRows(DirectionalAudio.allCases.map(\.label), selected: directionalLabel) { label in
+            checkedRows(
+                DirectionalAudio.allCases.map(\.label),
+                selected: model.session.status.directionalAudio?.label
+            ) { label in
                 if let value = DirectionalAudio.allCases.first(where: { $0.label == label }) {
                     model.session.setDirectionalAudio(value)
                 }
@@ -479,12 +495,14 @@ struct CapturePickerPanel: View {
 
     private var headerSubtitle: String {
         if isEvSheet { return "Compensation" }
+        if sheet == .shutter { return isAngleSheet ? "Angle" : "Speed" }
         return sheet.subtitle
     }
 
     private var modeTabs: [String] {
         switch sheet {
         case .iso where offersIsoAuto: ["Auto", "Manual"]
+        case .shutter where !isEvSheet: ["Speed", "Angle"]
         case .wb: ["Mode", "Kelvin", "Tint"]
         case .audio: ["Channel", "Wind", "Dir", "Vocal"]
         case .resolution: VideoResolution.allCases.map(\.tabTitle)
@@ -504,6 +522,10 @@ struct CapturePickerPanel: View {
         sheet == .shutter && model.session.status.expoMode == .auto
     }
 
+    private var isAngleSheet: Bool {
+        sheet == .shutter && !isEvSheet && selectedMode == 1
+    }
+
     private var isoIndices: [IsoIndex] {
         CaptureLists.isoIndices(from: model.session.status)
     }
@@ -514,6 +536,10 @@ struct CapturePickerPanel: View {
 
     private var shutterLabels: [String] {
         CaptureLists.shutterLabels(from: model.session.status)
+    }
+
+    private var shutterAngleLabels: [String] {
+        ShutterAngle.labels
     }
 
     private var isoDrumLabels: [String] {
@@ -553,16 +579,6 @@ struct CapturePickerPanel: View {
         return t > 0 ? "+\(t)" : "\(t)"
     }
 
-    private var windLabel: String? {
-        if case .wind(let w) = model.session.status.audioDspAt2 { return w.label }
-        return nil
-    }
-
-    private var directionalLabel: String? {
-        if case .directional(let d) = model.session.status.audioDspAt2 { return d.label }
-        return nil
-    }
-
     private func seed() {
         switch sheet {
         case .iso:
@@ -573,6 +589,9 @@ struct CapturePickerPanel: View {
                 reseatIso()
             }
         case .shutter:
+            if !isEvSheet {
+                selectedMode = OperatorPrefs.shutterUsesAngle ? 1 : 0
+            }
             reseatShutterOrEv()
         case .wb:
             let mode = model.session.status.whiteBalance?.mode
@@ -615,6 +634,9 @@ struct CapturePickerPanel: View {
                     model.session.setISO(idx)
                 }
             }
+        case .shutter:
+            OperatorPrefs.shutterUsesAngle = index == 1
+            reseatShutter()
         case .wb:
             if index == 0, model.session.status.whiteBalance?.mode != .auto {
                 // Mode tab only; write happens on row tap.
@@ -647,6 +669,16 @@ struct CapturePickerPanel: View {
             if isEvSheet {
                 guard let ev = EvComp(label: value) else { return }
                 enqueueDrumSend { model.session.setEv(ev) }
+                return
+            }
+            if isAngleSheet {
+                guard let degrees = ShutterAngle.parse(value) else { return }
+                OperatorPrefs.shutterAngleDegrees = degrees
+                let denom = ShutterAngle.denom(
+                    degrees: degrees,
+                    fps: model.session.status.fps,
+                    available: shutterDenoms)
+                enqueueDrumSend { model.session.setShutterDenom(denom) }
                 return
             }
             guard let denom = CamCapShutter.denom(from: value),
@@ -748,12 +780,39 @@ struct CapturePickerPanel: View {
     }
 
     private func reseatShutter() {
+        if isAngleSheet {
+            reseatShutterAngle()
+            return
+        }
         let labels = shutterLabels
         let live = model.session.status.shutterDenom > 0
             ? CamCapShutter.label(model.session.status.shutterDenom) : labels.first ?? ""
         let next = labels.contains(live) ? live : nearestShutter(live)
         lastApplied = next
         drumSelection = next
+    }
+
+    private func reseatShutterAngle() {
+        let fps = model.session.status.fps
+        let liveDenom = model.session.status.shutterDenom
+        let preferred = ShutterAngle.label(OperatorPrefs.shutterAngleDegrees)
+        if liveDenom > 0 {
+            let mapped = ShutterAngle.denom(
+                degrees: OperatorPrefs.shutterAngleDegrees, fps: fps, available: shutterDenoms)
+            if mapped == liveDenom, shutterAngleLabels.contains(preferred) {
+                lastApplied = preferred
+                drumSelection = preferred
+                return
+            }
+            let next = ShutterAngle.nearestLabel(denom: liveDenom, fps: fps)
+            OperatorPrefs.shutterAngleDegrees =
+                ShutterAngle.parse(next) ?? ShutterAngle.defaultDegrees
+            lastApplied = next
+            drumSelection = next
+            return
+        }
+        lastApplied = preferred
+        drumSelection = preferred
     }
 
     private func nearestShutter(_ label: String) -> String {
@@ -913,7 +972,7 @@ extension CaptureSheet {
     var subtitle: String {
         switch self {
         case .iso: "Sensitivity"
-        case .shutter: "Speed"
+        case .shutter: "Angle / speed"
         case .wb: "Kelvin / auto / tint"
         case .focus: "AF-S / AF-C"
         case .exposure: "Exposure"

--- a/ios/OpenPocketCine/LUTPicker.swift
+++ b/ios/OpenPocketCine/LUTPicker.swift
@@ -2,7 +2,8 @@ import OpenPocketViewCore
 import SwiftUI
 import UniformTypeIdentifiers
 
-/// Built-in / DJI / Custom, then 50/50.
+/// Built-in / DJI / Custom. 50/50 is pinned on the long-press footer so
+/// landscape never hides it under the catalog; the sheet keeps it inline.
 /// `embedded` is the assist-tray form; the sheet wraps the same body.
 struct LUTPicker: View {
     private enum Category: String, CaseIterable {
@@ -67,7 +68,11 @@ struct LUTPicker: View {
             tabContent
                 .frame(maxWidth: .infinity)
                 .frame(height: contentHeight)
-            splitComparisonControls
+            // Embedded long-press parks 50/50 on the panel footer so it
+            // stays on screen when the catalog scrolls.
+            if !embedded {
+                LUTSplitComparisonBar(assist: assist)
+            }
             if let importError {
                 Text(importError)
                     .font(LiveType.ui(size: 12, weight: .regular, design: .rounded))
@@ -120,51 +125,6 @@ struct LUTPicker: View {
             allowedContentTypes: [UTType(filenameExtension: "cube") ?? .data]
         ) { result in
             handleImport(result)
-        }
-    }
-
-    /// OpenZCine 50/50: off-by-default toggle; orientation chips only while armed.
-    /// Labels are `Left / Right` and `Top / Bottom`, not Vertical/Horizontal.
-    @ViewBuilder private var splitComparisonControls: some View {
-        HStack(spacing: 10) {
-            Button {
-                assist.splitComparison.toggle()
-                if assist.splitComparison {
-                    if !assist.lutArmed { assist.armLastLUT() }
-                }
-                assist.persist()
-            } label: {
-                HStack(spacing: 8) {
-                    Image(
-                        systemName: assist.splitComparison
-                            ? "checkmark.circle.fill" : "circle"
-                    )
-                    .foregroundStyle(
-                        assist.splitComparison ? LiveDesign.accent : LiveDesign.muted)
-                    Text("50/50")
-                        .font(LiveType.ui(size: 14, weight: .semibold, design: .rounded))
-                        .foregroundStyle(LiveDesign.text)
-                }
-                .padding(.vertical, 8)
-                .padding(.horizontal, 12)
-                .background(
-                    assist.splitComparison
-                        ? LiveDesign.accentDim : LiveDesign.glassBright,
-                    in: Capsule())
-            }
-            .buttonStyle(.zcTapTarget)
-            if assist.splitComparison {
-                LUTSegmentedButtons(
-                    items: LUTSplitOrientation.allCases.map(\.rawValue),
-                    selected: LUTSplitOrientation.current(vertical: assist.splitVertical).rawValue
-                ) { raw in
-                    guard let next = LUTSplitOrientation(rawValue: raw) else { return }
-                    assist.splitVertical = next.isVertical
-                    assist.persist()
-                }
-            } else {
-                Spacer(minLength: 0)
-            }
         }
     }
 
@@ -339,6 +299,58 @@ struct LUTPicker: View {
     private func clear(_ fileName: String) {
         pendingDeletion = nil
         assist.clearCustomFile(fileName)
+    }
+}
+
+/// OpenZCine 50/50: off-by-default toggle; orientation chips only while armed.
+/// Labels are `Left / Right` and `Top / Bottom`, not Vertical/Horizontal.
+///
+/// The long-press panel renders this as a pinned footer so opening LUT never
+/// hides the control under a catalog scroll.
+struct LUTSplitComparisonBar: View {
+    @Bindable var assist: LiveAssistState
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Button {
+                assist.splitComparison.toggle()
+                if assist.splitComparison {
+                    if !assist.lutArmed { assist.armLastLUT() }
+                }
+                assist.persist()
+            } label: {
+                HStack(spacing: 8) {
+                    Image(
+                        systemName: assist.splitComparison
+                            ? "checkmark.circle.fill" : "circle"
+                    )
+                    .foregroundStyle(
+                        assist.splitComparison ? LiveDesign.accent : LiveDesign.muted)
+                    Text("50/50")
+                        .font(LiveType.ui(size: 14, weight: .semibold, design: .rounded))
+                        .foregroundStyle(LiveDesign.text)
+                }
+                .padding(.vertical, 8)
+                .padding(.horizontal, 12)
+                .background(
+                    assist.splitComparison
+                        ? LiveDesign.accentDim : LiveDesign.glassBright,
+                    in: Capsule())
+            }
+            .buttonStyle(.zcTapTarget)
+            if assist.splitComparison {
+                LUTSegmentedButtons(
+                    items: LUTSplitOrientation.allCases.map(\.rawValue),
+                    selected: LUTSplitOrientation.current(vertical: assist.splitVertical).rawValue
+                ) { raw in
+                    guard let next = LUTSplitOrientation(rawValue: raw) else { return }
+                    assist.splitVertical = next.isVertical
+                    assist.persist()
+                }
+            } else {
+                Spacer(minLength: 0)
+            }
+        }
     }
 }
 

--- a/ios/OpenPocketCine/LiveAssists.swift
+++ b/ios/OpenPocketCine/LiveAssists.swift
@@ -630,6 +630,8 @@ enum OperatorPrefs {
     private static let cleanPinsKey = "OpenPocketCine.CleanViewPins.v1"
     private static let playbackAssistsKey = "OpenPocketCine.PlaybackAssists.v1"
     private static let portraitFeedAspectKey = "OpenPocketCine.PortraitFeedAspect"
+    private static let shutterUsesAngleKey = "OpenPocketCine.ShutterUsesAngle"
+    private static let shutterAngleKey = "OpenPocketCine.ShutterAngleDegrees"
 
     static var keepScreenAwake: Bool {
         get {
@@ -677,6 +679,21 @@ enum OperatorPrefs {
     static var dispClean: PocketDispChrome {
         get { loadChrome(key: dispCleanKey) ?? .cleanDefaults }
         set { saveChrome(newValue, key: dispCleanKey) }
+    }
+
+    static var shutterUsesAngle: Bool {
+        get { UserDefaults.standard.bool(forKey: shutterUsesAngleKey) }
+        set { UserDefaults.standard.set(newValue, forKey: shutterUsesAngleKey) }
+    }
+
+    static var shutterAngleDegrees: Double {
+        get {
+            let stored = UserDefaults.standard.double(forKey: shutterAngleKey)
+            return stored > 0 ? ShutterAngle.nearestDegrees(stored) : ShutterAngle.defaultDegrees
+        }
+        set {
+            UserDefaults.standard.set(ShutterAngle.nearestDegrees(newValue), forKey: shutterAngleKey)
+        }
     }
 
     static var portraitFeedAspect: PortraitFeedAspect {

--- a/ios/OpenPocketCine/LiveCameraControlBar.swift
+++ b/ios/OpenPocketCine/LiveCameraControlBar.swift
@@ -31,7 +31,9 @@ struct LiveCameraControlBar: View {
             if model.session.status.expoMode == .auto {
                 tile(.shutter, label: "EV", value: evValue, widest: "+3.0")
             } else {
-                tile(.shutter, label: "SHUTTER", value: shutterValue, widest: "1/16000")
+                tile(
+                    .shutter, label: "SHUTTER", value: shutterValue,
+                    widest: OperatorPrefs.shutterUsesAngle ? "346°" : "1/16000")
             }
             tile(.exposure, label: "MODE", value: expoValue, widest: "Manual")
             tile(.wb, label: "WB", value: wbValue, widest: "10000K", valueIcon: wbIcon)
@@ -104,6 +106,9 @@ struct LiveCameraControlBar: View {
     }
 
     private var shutterValue: String {
+        if OperatorPrefs.shutterUsesAngle {
+            return ShutterAngle.label(OperatorPrefs.shutterAngleDegrees)
+        }
         let d = model.session.status.shutterDenom
         return d > 0 ? "1/\(d)" : "—"
     }

--- a/ios/OpenPocketCineTests/AssistBarChromeTests.swift
+++ b/ios/OpenPocketCineTests/AssistBarChromeTests.swift
@@ -125,6 +125,22 @@ final class AssistBarChromeTests: XCTestCase {
         )
     }
 
+    func testLUTLandscapeWellKeepsPinnedSplitComparisonOnScreen() {
+        // Header + pad + 50/50 stay outside the catalog scroll. The landscape
+        // well must still have room for the catalog above that pinned chrome.
+        let well = AssistLongPressChrome.panelBox(
+            viewport: CGSize(width: 874, height: 402),
+            anchor: CGRect(x: 80, y: 330, width: 48, height: 58),
+            panel: CGSize(width: LUTAssist.longPressPanelWidth, height: 400),
+            toolbar: CGRect(x: 16, y: 330, width: 276, height: 58),
+            safeArea: EdgeInsets(top: 0, leading: 59, bottom: 21, trailing: 0),
+            ceilingY: 60 + 8
+        )
+        let pinnedChrome: CGFloat = 16 + 32 + 14 + 40 + 16
+        XCTAssertGreaterThan(well.maxHeight - pinnedChrome, 100)
+        XCTAssertLessThanOrEqual(well.y + well.maxHeight, 330 - 10 + 0.05)
+    }
+
     func testTallLUTPopupStartsBelowTopDeck() {
         let ceiling: CGFloat = 60 + 8
         let box = AssistLongPressChrome.panelBox(

--- a/ios/OpenPocketCineTests/CaptureListTests.swift
+++ b/ios/OpenPocketCineTests/CaptureListTests.swift
@@ -134,6 +134,14 @@ final class CaptureListTests: XCTestCase {
         ])
     }
 
+    func testShutterAngleLadderIsCalculatedNotCaptured() {
+        XCTAssertEqual(ShutterAngle.labels.first, "5.6°")
+        XCTAssertEqual(ShutterAngle.labels.last, "360°")
+        XCTAssertEqual(ShutterAngle.denom(degrees: 180, fps: 24), 48)
+        XCTAssertEqual(ShutterAngle.denom(degrees: 180, fps: 24, available: [25, 50, 100]), 50)
+        XCTAssertEqual(ShutterAngle.nearestLabel(denom: 48, fps: 24), "180°")
+    }
+
     func testEmptyCapListShowsOnlyCurrent() {
         var status = CameraStatus()
         status.shutterDenom = 80

--- a/ios/OpenPocketCineTests/LUTAssistTests.swift
+++ b/ios/OpenPocketCineTests/LUTAssistTests.swift
@@ -162,28 +162,40 @@ final class LUTAssistTests: XCTestCase {
     }
 
     func testOfficialCubesParseAsSize33() throws {
-        var sawAny = false
         for lut in OfficialPocketLUT.allCases {
             let url = officialCubeURL(lut.fileName)
-            guard FileManager.default.fileExists(atPath: url.path) else { continue }
-            sawAny = true
             let text = try String(contentsOf: url, encoding: .utf8)
             let cube = try CubeLUT.parse(text)
             XCTAssertEqual(cube.size, 33, lut.fileName)
             XCTAssertEqual(cube.rgb.count, 33 * 33 * 33 * 3, lut.fileName)
         }
         for lut in OfficialDJILUT.allCases {
+            XCTAssertNotNil(
+                Bundle.main.url(forResource: lut.resourceName, withExtension: "cube"),
+                "\(lut.fileName) must ship in the app bundle")
             let url = officialCubeURL(lut.fileName)
-            guard FileManager.default.fileExists(atPath: url.path) else { continue }
-            sawAny = true
             let text = try String(contentsOf: url, encoding: .utf8)
             let cube = try CubeLUT.parse(text)
             XCTAssertEqual(cube.size, 33, lut.fileName)
             XCTAssertEqual(cube.rgb.count, 33 * 33 * 33 * 3, lut.fileName)
+            XCTAssertNotNil(BundledOfficialDJILUT.cube(lut), lut.fileName)
         }
-        if !sawAny {
-            throw XCTSkip("official LUT cubes are local-only")
+    }
+
+    func testArmedDJIAutoDLog2BindsOfficialCube() {
+        let assist = LiveAssistState()
+        assist.selectLUT(.djiAuto)
+        assist.syncLUT(to: .dLog2, family: .pocket, cameraName: "Osmo Pocket 4 Pro")
+        XCTAssertEqual(assist.lutSelection, .djiAuto)
+        XCTAssertEqual(assist.resolvedSource(), .dji(.pocketDLog2))
+        XCTAssertEqual(assist.lutStatusLabel, "DJI Auto · D-Log2 → Rec.709")
+        guard BundledOfficialDJILUT.cube(.pocketDLog2) != nil else {
+            XCTFail("official DJI D-Log2 cube must load from the app bundle")
+            return
         }
+        XCTAssertEqual(assist.effects.lutDimension, 33)
+        XCTAssertFalse(assist.effects.lutRGBA.isEmpty)
+        XCTAssertTrue(assist.effects.needsGPUFeed)
     }
 
     func testOfficialDLog2CubeMovesMidGrey() throws {
@@ -197,7 +209,7 @@ final class LUTAssistTests: XCTestCase {
         XCTAssertLessThan(black.red, 0.04, "log black must become a real Rec.709 black")
     }
 
-    func testArmedAutoDLog2BindsOfficialCube() throws {
+    func testArmedAutoDLog2BindsOfficialCube() {
         let assist = LiveAssistState()
         XCTAssertTrue(assist.lutEnabled)
         assist.syncLUT(to: .dLog2)
@@ -205,7 +217,8 @@ final class LUTAssistTests: XCTestCase {
         XCTAssertEqual(assist.resolvedSource(), .official(.dLog2ToRec709))
         XCTAssertEqual(assist.lutStatusLabel, "Auto · D-Log2 → Rec.709")
         guard BundledPocketLUT.cube(.dLog2ToRec709) != nil else {
-            throw XCTSkip("official D-Log2 cube is local-only")
+            XCTFail("official D-Log2 cube must load from the app bundle")
+            return
         }
         XCTAssertEqual(assist.effects.lutDimension, 33)
         XCTAssertFalse(assist.effects.lutRGBA.isEmpty)
@@ -273,11 +286,7 @@ final class LUTAssistTests: XCTestCase {
     }
 
     private func officialCube(_ lut: OfficialPocketLUT) throws -> CubeLUT {
-        let url = officialCubeURL(lut.fileName)
-        guard FileManager.default.fileExists(atPath: url.path) else {
-            throw XCTSkip("official LUT \(lut.fileName) is local-only")
-        }
-        return try CubeLUT.parse(String(contentsOf: url, encoding: .utf8))
+        try CubeLUT.parse(String(contentsOf: officialCubeURL(lut.fileName), encoding: .utf8))
     }
 
     private func officialCubeURL(_ fileName: String) -> URL {

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,15 +1,17 @@
 New and changed
 
-- The Home Screen icon and launch mark are now a production monitor: REC, waveform, and a center cross on black.
+- The SHUTTER sheet has Speed and Angle tabs. Angle runs 5.6° to 360° and is sent as the matching 1/N.
+- Opening LUT keeps 50/50 on screen instead of scrolling it under the catalog.
+- AUDIO Channel, Wind, Dir, and Vocal now stay on the value you pick.
 
 Fixes
 
-- Nothing to call out yet — this build is an icon refresh.
+- Wind and directional rows could bounce back after a tap because the previous DSP byte was still on screen.
+- LUT 50/50 could sit off-screen in landscape.
 
 What to test
 
-- After install, confirm the Home Screen icon is the production-monitor mark, not the previous tile.
-- Open the app and confirm the same mark on the launch splash.
-- Pair an Osmo Pocket 4 or 4 Pro, join its Wi-Fi, and confirm live view fills the monitor.
-- Start and stop a take from the phone, then confirm it on the camera body.
-
+- In Manual, open SHUTTER, switch to Angle, pick 180°, and confirm the tile shows 180°.
+- Change frame rate with Angle armed and confirm the angle holds.
+- Long-press LUT in landscape and confirm 50/50 is visible without scrolling.
+- Open AUDIO, walk Channel / Wind / Dir / Vocal, and confirm each row stays selected.


### PR DESCRIPTION
## What & why

Yesterday's SHUTTER Angle work (and two other sheet follow-ups) were implemented on the capricorn workspace and installed on the phone, then never committed. PR #13 merged at 20:31 from commits that stopped at 19:40 (official DJI LUTs). The orca workspace went away, so the files died with it.

This restores that uncommitted tree:

**Shutter angle.** SHUTTER grows Speed / Angle tabs (Manual only; Auto still opens EV). Angle is ours — 5.6°–360°, same ladder as the cinema sheet — converted with `angle = 360 × fps / denom` and snapped to the body's legal 1/N. The SHUTTER tile shows degrees while Angle is armed. Changing frame rate rewrites 1/N so the angle holds.

**LUT 50/50.** Long-press LUT pins 50/50 on the panel footer so landscape no longer scrolls it under the catalog. The full-screen LUT sheet still shows it inline.

**AUDIO sheet.** Channel / Wind / Dir / Vocal write and stay selected. Wind and directional are first-class status (directional bytes include wind-on), and SET pins absorb stale DSP snapshots.

Official DJI LUT tabs and cubes were already on `main` from PR #13. Not restored: Android shutter-angle UI (the original pass was iOS-only).

## TestFlight notes

Replaced `ios/TestFlight/WhatToTest.en-US.txt` for Angle, LUT 50/50, and AUDIO selection.

## Checklist

- [x] `swift test` — 394 tests, 35 suites, pass. `just check` editorconfig still fails on pre-existing `site/assets/app.css` (untouched).
- [x] iOS: CaptureListTests, AssistBarChromeTests, LUTAssistTests on the booted iPhone 16 sim. Device confirm of SHUTTER Angle / LUT 50/50 / AUDIO still needed on hardware.
- [x] Commits follow Conventional Commits.
- [x] No captures, Wi-Fi passwords, unofficial LUT dumps, signing material, or other secrets.
- [x] CHANGELOG updated.
- [x] TestFlight-triggering changes include reviewed `ios/TestFlight/WhatToTest.en-US.txt` copy.
- [ ] iOS release version bump not in this PR (same train).