### PR TITLE
fix: rebuild UDP when live enable produces no video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- A live-view enable that produces no video packets rebuilds UDP after 2 s
+  instead of holding an 8 s IDR window (the 15 s black well after leaving a
+  clip).
 - LUT 50/50 stays pinned when the catalog scrolls, so landscape no longer hides
   it.
 - AUDIO Channel, Wind, Dir, and Vocal stay on the value you pick instead of

--- a/Sources/OpenPocketViewCore/FeedWatchdog.swift
+++ b/Sources/OpenPocketViewCore/FeedWatchdog.swift
@@ -159,12 +159,34 @@ public struct FeedWatchdog: Equatable, Sendable {
         videoPackets > 0 || lastVideoPacketAge != nil
     }
 
+    /// HEVC landed after this `0x09/0xa8` — the IDR gap, not a still-paused encoder.
+    public static func enableRestartedVideo(
+        secondsSinceLastEnable: TimeInterval?,
+        lastVideoPacketAge: TimeInterval?
+    ) -> Bool {
+        guard let since = secondsSinceLastEnable, let video = lastVideoPacketAge else {
+            return false
+        }
+        return video + 0.05 < since
+    }
+
     /// `0x09/0xa8` cuts the encoder GOP. Warm cameras answer in 25–167 ms;
     /// a fresh-boot / mid-session enable can stay silent for a few seconds.
     /// Tearing UDP in that gap is the LUT-toggle / first-picture black feed.
-    public static func shouldHoldForGOPReset(secondsSinceLastEnable: TimeInterval?) -> Bool {
-        guard let since = secondsSinceLastEnable else { return false }
-        return since < CameraSoftAP.firstPictureIDRGrace
+    ///
+    /// If HEVC has been silent *longer* than this enable, the enable did not
+    /// restart the encoder — do not sit in the 8s IDR window.
+    public static func shouldHoldForGOPReset(
+        secondsSinceLastEnable: TimeInterval?,
+        lastVideoPacketAge: TimeInterval? = nil
+    ) -> Bool {
+        guard let since = secondsSinceLastEnable, since < CameraSoftAP.firstPictureIDRGrace else {
+            return false
+        }
+        if let video = lastVideoPacketAge, video > since + stallThreshold {
+            return false
+        }
+        return true
     }
 
     /// Only the first time a hardware decoder that cannot join mid-GOP starts.
@@ -206,8 +228,17 @@ public struct FeedWatchdog: Equatable, Sendable {
         pathReady: Bool,
         lastBleNotifyAge: TimeInterval?,
         hadVideo: Bool = true,
-        holdEnableCount: Int = 1
+        holdEnableCount: Int = 1,
+        lastVideoPacketAge: TimeInterval? = nil
     ) -> Bool {
+        if hadVideo,
+            let video = lastVideoPacketAge,
+            video > secondsSinceLastEnable + stallThreshold
+        {
+            // Last enable produced no HEVC. Another 0x09/0xa8 blacks the well;
+            // the watchdog should reopen UDP instead.
+            return false
+        }
         if !hadVideo {
             return secondsSinceLastEnable >= stallThreshold
         }
@@ -237,7 +268,10 @@ public struct FeedWatchdog: Equatable, Sendable {
             return .none
         }
 
-        if Self.shouldHoldForGOPReset(secondsSinceLastEnable: snap.secondsSinceLastEnable) {
+        if Self.shouldHoldForGOPReset(
+            secondsSinceLastEnable: snap.secondsSinceLastEnable,
+            lastVideoPacketAge: snap.lastVideoPacketAge
+        ) {
             return .none
         }
 
@@ -265,9 +299,18 @@ public struct FeedWatchdog: Equatable, Sendable {
             }
         }
 
-        // Encoder pause: status still on 9004, HEVC silent. One enable,
-        // never reopen UDP. escalateAfter (5 s) between 0x09/0xa8.
+        // Encoder pause: status still on 9004, HEVC silent. One enable.
+        // If that enable produced no video packets, the encoder is still
+        // paused — reopen UDP instead of sitting in GOP-reset grace.
         if snap.hadVideo, Self.controlReceiveAlive(snap), !Self.udpReceiveAlive(snap) {
+            if stage == .resendEnable,
+                !Self.enableRestartedVideo(
+                    secondsSinceLastEnable: snap.secondsSinceLastEnable,
+                    lastVideoPacketAge: snap.lastVideoPacketAge),
+                snap.now - lastActionAt >= Self.stallThreshold
+            {
+                return fire(.reopenDatalink, at: snap.now)
+            }
             if stage == .idle || snap.now - lastActionAt >= Self.escalateAfter {
                 return fire(.resendLiveViewEnable, at: snap.now)
             }
@@ -288,7 +331,9 @@ public struct FeedWatchdog: Equatable, Sendable {
         }
 
         if stage == .cooldown {
-            if Self.shouldHoldBind(pathReady: snap.pathReady, lastBleNotifyAge: snap.lastBleNotifyAge) {
+            if Self.shouldHoldBind(
+                pathReady: snap.pathReady, lastBleNotifyAge: snap.lastBleNotifyAge)
+            {
                 return .none
             }
             if snap.now - lastActionAt >= Self.cooldownDuration {
@@ -324,7 +369,8 @@ public struct FeedWatchdog: Equatable, Sendable {
         }
         let flow = snap.flowHealthy ? "ready" : "dead"
         let prefix = snap.displayedImageRemoved ? "feed: black" : "feed: stall"
-        return "\(prefix) lastFrame=\(age(snap.lastDecodedFrameAge))s lastVideo=\(age(snap.lastVideoPacketAge))s lastAU=\(age(snap.lastAccessUnitAge))s lastStatus=\(age(snap.lastStatusAge))s lastBle=\(age(snap.lastBleNotifyAge))s flow=\(flow) tcp=\(snap.tcpPokeReady ? 1 : 0) path=\(snap.pathReady ? 1 : 0) format=\(snap.hasFormat ? 1 : 0) stage=\(stage.rawValue) recoverBlack=\(snap.displayedImageRemoved ? 1 : 0)"
+        return
+            "\(prefix) lastFrame=\(age(snap.lastDecodedFrameAge))s lastVideo=\(age(snap.lastVideoPacketAge))s lastAU=\(age(snap.lastAccessUnitAge))s lastStatus=\(age(snap.lastStatusAge))s lastBle=\(age(snap.lastBleNotifyAge))s flow=\(flow) tcp=\(snap.tcpPokeReady ? 1 : 0) path=\(snap.pathReady ? 1 : 0) format=\(snap.hasFormat ? 1 : 0) stage=\(stage.rawValue) recoverBlack=\(snap.displayedImageRemoved ? 1 : 0)"
     }
 
     /// Wipe the display layer only when the next decoded picture is in hand.

--- a/Sources/OpenPocketViewCore/LinkDiagnosis.swift
+++ b/Sources/OpenPocketViewCore/LinkDiagnosis.swift
@@ -49,7 +49,10 @@ public enum LinkDiagnoser {
         {
             return .presentStalled
         }
-        if FeedWatchdog.shouldHoldForGOPReset(secondsSinceLastEnable: secondsSinceLastEnable) {
+        if FeedWatchdog.shouldHoldForGOPReset(
+            secondsSinceLastEnable: secondsSinceLastEnable,
+            lastVideoPacketAge: videoAge
+        ) {
             return .none
         }
         if FocusTrackMode.shouldHoldWatchdog(secondsSinceSet: secondsSinceFocusTrackSet) {

--- a/Tests/OpenPocketViewCoreTests/FeedWatchdogTests.swift
+++ b/Tests/OpenPocketViewCoreTests/FeedWatchdogTests.swift
@@ -79,6 +79,40 @@ import Testing
         #expect(dog.stage == .resendEnable)
     }
 
+    @Test func enableThatProducesNoHEVCRebuildsUDP() {
+        var dog = FeedWatchdog()
+        var snap = Self.snap(
+            now: 10, frameAge: 2.8, videoAge: 2.8, statusAge: 0.0, bleAge: 232)
+        snap.secondsSinceLastEnable = 20
+        #expect(dog.tick(snap) == .resendLiveViewEnable)
+        #expect(dog.stage == .resendEnable)
+
+        // Same stall as the field log: enable #7, videoPkts frozen, status still young.
+        snap.now = 12.1
+        snap.lastDecodedFrameAge = 4.9
+        snap.lastVideoPacketAge = 4.9
+        snap.lastAccessUnitAge = 4.9
+        snap.lastStatusAge = 0.0
+        snap.secondsSinceLastEnable = 2.1
+        #expect(
+            !FeedWatchdog.shouldHoldForGOPReset(
+                secondsSinceLastEnable: 2.1, lastVideoPacketAge: 4.9))
+        #expect(
+            dog.tick(snap) == .reopenDatalink,
+            "enable produced no HEVC — reopen UDP instead of 8s IDR hold")
+        #expect(dog.stage == .reopenDatalink)
+        #expect(
+            !FeedWatchdog.shouldRepeatRecoverEnable(
+                secondsSinceLastEnable: 2.1,
+                secondsSinceLastRebuild: nil,
+                pathReady: true,
+                lastBleNotifyAge: 232,
+                hadVideo: true,
+                holdEnableCount: 1,
+                lastVideoPacketAge: 4.9),
+            "do not spam 0x09/0xa8 while videoPkts are frozen")
+    }
+
     @Test func gopResetSilenceDoesNotRebuildUDP() {
         var dog = FeedWatchdog()
         var snap = Self.snap(now: 10, frameAge: 3.0, videoAge: 3.0, bleAge: 0.2)
@@ -89,6 +123,14 @@ import Testing
         #expect(FeedWatchdog.shouldHoldForGOPReset(secondsSinceLastEnable: 7.9))
         #expect(!FeedWatchdog.shouldHoldForGOPReset(secondsSinceLastEnable: 8.0))
         #expect(!FeedWatchdog.shouldHoldForGOPReset(secondsSinceLastEnable: nil))
+        #expect(
+            FeedWatchdog.shouldHoldForGOPReset(
+                secondsSinceLastEnable: 2.5, lastVideoPacketAge: 0.4),
+            "HEVC after enable is the IDR gap")
+        #expect(
+            !FeedWatchdog.shouldHoldForGOPReset(
+                secondsSinceLastEnable: 1.0, lastVideoPacketAge: 3.8),
+            "video died before this enable — not an IDR gap")
 
         snap.secondsSinceLastEnable = 8.1
         snap.lastStatusAge = 8.1

--- a/ios/OpenPocketCine/CameraSession.swift
+++ b/ios/OpenPocketCine/CameraSession.swift
@@ -2616,7 +2616,8 @@ final class CameraSession {
             secondsSinceLastRebuild: datalink?.secondsSinceLastRebuild
         ) else { return }
         if FeedWatchdog.shouldHoldForGOPReset(
-            secondsSinceLastEnable: now.timeIntervalSince(lastIdrRequest)
+            secondsSinceLastEnable: now.timeIntervalSince(lastIdrRequest),
+            lastVideoPacketAge: datalink?.lastVideoPacketAt.map { now.timeIntervalSince($0) }
         ) {
             log.info("control: SET timeouts during GOP-reset grace — leave UDP")
             return
@@ -2644,7 +2645,8 @@ final class CameraSession {
     private var shouldStartUDPRebuild: Bool {
         let now = Date()
         if FeedWatchdog.shouldHoldForGOPReset(
-            secondsSinceLastEnable: now.timeIntervalSince(lastIdrRequest)
+            secondsSinceLastEnable: now.timeIntervalSince(lastIdrRequest),
+            lastVideoPacketAge: datalink?.lastVideoPacketAt.map { now.timeIntervalSince($0) }
         ) {
             return false
         }
@@ -2668,6 +2670,7 @@ final class CameraSession {
     /// A frozen first GOP still has `lastPresentedAt` — that must not skip recover.
     private func recoverLiveViewIfNeeded() {
         guard !isBrowsingMedia, !holdsMonitor else { return }
+        if needsForegroundRecover { return }
         guard WiFiJoiner.isCameraPathReady() else { return }
         if MediaLiveResume.strayPlaybackAction(
             browsing: isBrowsingMedia, inPlayback: status.inPlayback) != nil
@@ -2696,16 +2699,18 @@ final class CameraSession {
         // at 5s if this hold has only fired once; then the 60s backoff.
         if decoder.awaitingIDR {
             let bleAge = lastBleNotifyAt.map { Date().timeIntervalSince($0) }
+            let videoAge = datalink?.lastVideoPacketAt.map { Date().timeIntervalSince($0) }
             let hadVideo = FeedWatchdog.hadVideo(
                 videoPackets: datalink?.videoPackets ?? 0,
-                lastVideoPacketAge: datalink?.lastVideoPacketAt.map { Date().timeIntervalSince($0) })
+                lastVideoPacketAge: videoAge)
             if FeedWatchdog.shouldRepeatRecoverEnable(
                 secondsSinceLastEnable: Date().timeIntervalSince(lastIdrRequest),
                 secondsSinceLastRebuild: datalink?.secondsSinceLastRebuild,
                 pathReady: true,
                 lastBleNotifyAge: bleAge,
                 hadVideo: hadVideo,
-                holdEnableCount: idrHoldEnableCount
+                holdEnableCount: idrHoldEnableCount,
+                lastVideoPacketAge: videoAge
             ) {
                 log.info("live: still holding for IDR — re-request enable")
                 sendRecoverEnable(force: true, reason: "still holding for IDR")
@@ -2759,6 +2764,7 @@ final class CameraSession {
     }
 
     private func applyFeedWatchdog() {
+        if needsForegroundRecover { return }
         let now = Date()
         let live: Bool
         if case .live = phase { live = true } else { live = false }
@@ -2790,7 +2796,9 @@ final class CameraSession {
         switch action {
         case .none:
             if !FeedWatchdog.udpReceiveAlive(snap),
-               FeedWatchdog.shouldHoldForGOPReset(secondsSinceLastEnable: snap.secondsSinceLastEnable)
+                FeedWatchdog.shouldHoldForGOPReset(
+                    secondsSinceLastEnable: snap.secondsSinceLastEnable,
+                    lastVideoPacketAge: snap.lastVideoPacketAge)
             {
                 log.info(
                     "feed: hold UDP rebuild — GOP-reset grace lastEnable=\(snap.secondsSinceLastEnable ?? -1, format: .fixed(precision: 1), privacy: .public)s lastVideo=\(snap.lastVideoPacketAge ?? -1, format: .fixed(precision: 1), privacy: .public)s")

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -9,6 +9,7 @@ New and changed
 
 Fixes
 
+- After leaving a clip, a dead picture with live camera status rebuilds the socket in about two seconds instead of sitting black for 15.
 - The live feed comes up as soon as the camera answers, instead of waiting out extra beats.
 - If the camera is still talking but the picture dies, the app asks for a fresh frame instead of sitting on a black well.
 - A Bluetooth or camera-Wi-Fi drop now leaves the live screen instead of pretending the feed is still up.
@@ -17,7 +18,7 @@ Fixes
 What to test
 
 - Pair a saved Pocket 4 or 4 Pro. Confirm the picture and LUT appear together, then gimbal still works.
+- Open a clip, leave it, and confirm live view returns in a couple of seconds — not a long black well.
 - Background the app, return, and confirm the feed comes back without a full re-pair.
 - On ISO, turn Auto Native ISO off, switch D-Log ↔ D-Log2, and confirm ISO stays put.
 - In Manual, open SHUTTER, switch to Angle, pick 180°, and confirm the tile shows 180°.
-- Long-press LUT in landscape and confirm 50/50 is visible without scrolling.


### PR DESCRIPTION
## What & why

Field log: after leaving a clip the picture died for ~15–20s, then came back. UDP status stayed fresh (`lastStatus=0.0s`) while HEVC stopped (`videoPkts` frozen at 64166). The watchdog treated that as an encoder pause, sent `0x09/0xa8`, and held an 8s GOP-reset / IDR window. No IDR arrived, a second enable still produced no packets, then scene-inactive delayed the foreground UDP rebuild that actually recovered.

`0x09/0xa8` that does not restart HEVC is not an IDR gap. After 2s with no video packet younger than the enable, reopen UDP. Do not spam another enable while packets are frozen. Skip the watchdog while the scene is inactive so backgrounding cannot send another GOP-reset.

## TestFlight notes

Updated. Lead test: open a clip, leave it, confirm live view returns in a couple of seconds.

## Checklist

- [x] `swift test` — FeedWatchdogTests + LinkDiagnosisTests pass, including the new frozen-`videoPkts` case.
- [ ] Device: open a clip, back to live, confirm no 15s black well. Compile-only is not enough for this.
- [x] Commits follow Conventional Commits.
- [x] No captures, Wi-Fi passwords, unofficial LUT dumps, signing material, or other secrets.
- [x] CHANGELOG updated.
- [x] TestFlight notes updated.
- [ ] iOS release version bump not in this PR (same train).