### PR TITLE
docs: add a quiet README support note

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+buy_me_a_coffee: eriksutton

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project are documented here. The format is based on
   zebra, false color, waveform, histogram, guides).
 - Android Jetpack Compose shell in `Apps/Android/` consuming the same Swift core over JNI.
 - Public repository hygiene: `just check`, secret scan, landing page at openpocketcine.app.
+- README support note for optional [Buy Me a Coffee](https://buymeacoffee.com/eriksutton)
+  contributions, with a nod to animal charities.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,13 @@ Contributions are welcome!
 
 Please also read our [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md). For security issues, see [`SECURITY.md`](SECURITY.md).
 
+## Support
+
+I truly appreciate everyone who uses this project, files an issue, or sends a
+patch. Optional [Buy Me a Coffee](https://buymeacoffee.com/eriksutton) contributions
+help keep the lights on. If you would rather give to a charity — especially one
+that helps animals — that is just as welcome.
+
 ## License
 
 [Apache 2.0](LICENSE). Third-party licenses are listed in


### PR DESCRIPTION
## What & why

A short Support section at the bottom of the README (after Contributing, before License): thanks, optional [Buy Me a Coffee](https://buymeacoffee.com/eriksutton), and that a gift to a charity — especially one that helps animals — is just as welcome.

`.github/FUNDING.yml` points GitHub’s Sponsor button at the same Buy Me a Coffee page so the ask is not only in the README.

## TestFlight notes

Docs-only. No tester-facing app behavior.

## Checklist

- [x] `just lint-md`, `just typos`, `just check-links`, `just hygiene`, `just secrets` pass for the paths touched.
- [x] Commits follow Conventional Commits.
- [x] No captures, Wi-Fi passwords, unofficial LUT dumps, signing material, or other secrets.
- [x] Docs/CHANGELOG updated.
- [x] Not a TestFlight-triggering change.