### PR TITLE
fix: default Traffic Lights compensation to 0 stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project are documented here. The format is based on
 
 ### Changed
 
+- Traffic Lights crush/clip compensation defaults to 0 stops (was ¼).
 - Replace the app mark across iOS, Android, and the landing page with the
   production-monitor icon.
 - First picture and persisted LUT start together: VideoToolbox opens at the

--- a/Sources/OpenPocketViewCore/LiveColorScience.swift
+++ b/Sources/OpenPocketViewCore/LiveColorScience.swift
@@ -520,8 +520,8 @@ public struct ScopeTrafficLightsReading: Equatable, Sendable {
 }
 
 public enum ScopeTrafficLights {
-    /// Default pixel-fraction threshold = 0.25 stop compensation (stops / 10).
-    public static let defaultThreshold = 0.025
+    /// Default pixel-fraction threshold = 0 stop compensation (stops / 10).
+    public static let defaultThreshold = 0.0
     /// Stay lit until energy falls to half the fire threshold (stops blink).
     public static let holdRatio = 0.5
 

--- a/Tests/OpenPocketViewCoreTests/LiveColorScienceTests.swift
+++ b/Tests/OpenPocketViewCoreTests/LiveColorScienceTests.swift
@@ -354,21 +354,24 @@ struct LiveColorScienceTests {
     }
 
     @Test func clipLampsHoldThroughThresholdChatter() {
+        let quarter = 0.025
         var bins = [Int](repeating: 0, count: 256)
         bins[128] = 970
         bins[247] = 30
         let on = ScopeTrafficLights.reading(
-            red: bins, green: bins, blue: bins, transfer: .dlog2)
+            red: bins, green: bins, blue: bins, transfer: .dlog2, threshold: quarter)
         #expect(on.anyClip)
         bins[247] = 20
         bins[128] = 980
         let held = ScopeTrafficLights.reading(
-            red: bins, green: bins, blue: bins, transfer: .dlog2, previous: on)
+            red: bins, green: bins, blue: bins, transfer: .dlog2, threshold: quarter,
+            previous: on)
         #expect(held.anyClip, "2.0% after 3.0% must stay lit (half of 2.5%)")
         bins[247] = 10
         bins[128] = 990
         let off = ScopeTrafficLights.reading(
-            red: bins, green: bins, blue: bins, transfer: .dlog2, previous: held)
+            red: bins, green: bins, blue: bins, transfer: .dlog2, threshold: quarter,
+            previous: held)
         #expect(!off.anyClip, "1.0% drops the latch")
     }
 
@@ -383,15 +386,19 @@ struct LiveColorScienceTests {
     }
 
     @Test func thresholdLadderIsStopsOverTen() {
-        // 2.6% clipped fires the default 0.25-stop (2.5%) threshold; 2.4% does not.
+        #expect(ScopeTrafficLights.defaultThreshold == 0)
+        // 2.6% clipped fires a 0.25-stop (2.5%) threshold; 2.4% does not.
+        let quarter = 0.025
         var bins = [Int](repeating: 0, count: 256)
         bins[128] = 974
         bins[255] = 26
-        var reading = ScopeTrafficLights.reading(red: bins, green: bins, blue: bins, transfer: .dlog2)
+        var reading = ScopeTrafficLights.reading(
+            red: bins, green: bins, blue: bins, transfer: .dlog2, threshold: quarter)
         #expect(reading.anyClip)
         bins[255] = 24
         bins[128] = 976
-        reading = ScopeTrafficLights.reading(red: bins, green: bins, blue: bins, transfer: .dlog2)
+        reading = ScopeTrafficLights.reading(
+            red: bins, green: bins, blue: bins, transfer: .dlog2, threshold: quarter)
         #expect(!reading.anyClip)
         // One-stop compensation (10%): 9% does not fire.
         bins[255] = 90

--- a/ios/OpenPocketCine/Assists/HistogramAssist.swift
+++ b/ios/OpenPocketCine/Assists/HistogramAssist.swift
@@ -152,14 +152,14 @@ enum HistogramAssist {
 
         static let `default` = Options(
             trafficLights: true,
-            crushClipCompensation: .quarter,
+            crushClipCompensation: .zero,
             scale: defaultScale,
             storedCenter: nil,
             storedCenterPortrait: nil)
 
         init(
             trafficLights: Bool = true,
-            crushClipCompensation: CrushClipCompensation = .quarter,
+            crushClipCompensation: CrushClipCompensation = .zero,
             scale: Double = defaultScale,
             storedCenter: StoredCenter? = nil,
             storedCenterPortrait: StoredCenter? = nil
@@ -180,7 +180,7 @@ enum HistogramAssist {
             trafficLights = try c.decodeIfPresent(Bool.self, forKey: .trafficLights) ?? true
             crushClipCompensation =
                 try c.decodeIfPresent(CrushClipCompensation.self, forKey: .crushClipCompensation)
-                ?? .quarter
+                ?? .zero
             scale = Self.clampedScale(
                 try c.decodeIfPresent(Double.self, forKey: .scale) ?? defaultScale)
             storedCenter = try c.decodeIfPresent(StoredCenter.self, forKey: .storedCenter)

--- a/ios/OpenPocketCine/Assists/TrafficLightsAssist.swift
+++ b/ios/OpenPocketCine/Assists/TrafficLightsAssist.swift
@@ -15,7 +15,7 @@ enum TrafficLightsAssist {
     static let baseSize = CGSize(width: 74, height: 168)
     static let scaleRange: ClosedRange<Double> = 0.6...1.6
     static let defaultScale = 1.0
-    static let defaultCompensation = CrushClipCompensation.quarter
+    static let defaultCompensation = CrushClipCompensation.zero
     static let longPressPanelWidth: CGFloat = 400
     static let compensationTitle = "Crush/Clip Compensation"
     static let compensationHelp =

--- a/ios/OpenPocketCine/LiveAssists.swift
+++ b/ios/OpenPocketCine/LiveAssists.swift
@@ -245,7 +245,7 @@ final class LiveAssistState {
     /// Icon (or toolbar) frame in `LiveCanvasSpace` for the long-press options popup.
     var longPressAnchor: CGRect = .zero
     /// OpenZCine `scopes.crushClipCompensation` — shared by HISTO edge lights and LIGHTS.
-    var crushClipCompensation = TrafficLightsAssist.CrushClipCompensation.quarter
+    var crushClipCompensation = TrafficLightsAssist.defaultCompensation
     var trafficLightsScale = TrafficLightsAssist.defaultScale
     var trafficLightsPosition: TrafficLightsAssist.StoredCenter?
     /// First-launch default is on — Auto applies the matching official cube.

--- a/ios/OpenPocketCineTests/HistogramAssistTests.swift
+++ b/ios/OpenPocketCineTests/HistogramAssistTests.swift
@@ -13,7 +13,7 @@ final class HistogramAssistTests: XCTestCase {
         XCTAssertEqual(HistogramAssist.defaultScale, 1.0)
         XCTAssertEqual(HistogramAssist.holdDuration, 0.3)
         XCTAssertEqual(HistogramAssist.Options.default.trafficLights, true)
-        XCTAssertEqual(HistogramAssist.Options.default.crushClipCompensation, .quarter)
+        XCTAssertEqual(HistogramAssist.Options.default.crushClipCompensation, .zero)
         XCTAssertEqual(HistogramAssist.Options.default.scale, 1.0)
         XCTAssertNil(HistogramAssist.Options.default.storedCenter)
     }
@@ -240,7 +240,7 @@ final class HistogramAssistTests: XCTestCase {
             HistogramAssist.Options.self, from: Data(#"{"scale":0.7,"trafficLights":false}"#.utf8))
         XCTAssertEqual(scaled.scale, 0.7, accuracy: 1e-12)
         XCTAssertFalse(scaled.trafficLights)
-        XCTAssertEqual(scaled.crushClipCompensation, .quarter)
+        XCTAssertEqual(scaled.crushClipCompensation, .zero)
     }
 
     func testCompensationThresholdDrivesTrafficLights() {

--- a/ios/OpenPocketCineTests/TrafficLightsAssistTests.swift
+++ b/ios/OpenPocketCineTests/TrafficLightsAssistTests.swift
@@ -27,7 +27,7 @@ final class TrafficLightsAssistTests: XCTestCase {
             TrafficLightsAssist.CrushClipCompensation.one.pixelFractionThreshold, 0.10,
             accuracy: 1e-12)
         XCTAssertEqual(TrafficLightsAssist.CrushClipCompensation.quarter.rawValue, 2)
-        XCTAssertEqual(TrafficLightsAssist.defaultCompensation, .quarter)
+        XCTAssertEqual(TrafficLightsAssist.defaultCompensation, .zero)
         XCTAssertEqual(TrafficLightsAssist.longPressPanelWidth, 400)
         XCTAssertEqual(TrafficLightsAssist.compensationTitle, "Crush/Clip Compensation")
         XCTAssertEqual(

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -9,6 +9,7 @@ New and changed
 
 Fixes
 
+- Traffic Lights crush/clip compensation starts at 0 stops. Long-press LIGHTS if you want the old ¼-stop tolerance.
 - First connect no longer sits on Waiting for live-view when a few video packets arrive and then freeze.
 - While a subject is tracked, stick left/right matches the free gimbal instead of reversing.
 - Turn Face Priority off and EV returns to the value from before it was on, or 0.0.


### PR DESCRIPTION
## What & why

Crush/clip compensation on Traffic Lights (shared with HISTO) now defaults to **0 stops** instead of ¼. Lamps fire as soon as there is energy in the crush/clip band.

Settings → reset LIGHTS, or a fresh install, pick up 0. A phone that already saved ¼ keeps that until you long-press LIGHTS and choose 0.

## TestFlight notes

Updated. Testers: long-press LIGHTS if you still want the old ¼-stop tolerance.

## Checklist

- [x] Core `LiveColorScienceTests` pass.
- [x] Commits follow Conventional Commits.
- [x] CHANGELOG and TestFlight notes updated.