### PR TITLE
fix: stop clipping phone mockup shadows on mobile

### DIFF
--- a/site/assets/app.css
+++ b/site/assets/app.css
@@ -448,7 +448,9 @@ h3 { font-size: clamp(20px, 2.2vw, 24px); line-height: 1.25; letter-spacing: -0.
   align-items: center;
   gap: clamp(28px, 5vw, 72px);
   text-align: left;
+  overflow: visible;
 }
+.feat-section { overflow: visible; }
 .feat-row--reverse {
   grid-template-columns: minmax(260px, 1.1fr) minmax(240px, 0.9fr);
 }
@@ -478,11 +480,10 @@ h3 { font-size: clamp(20px, 2.2vw, 24px); line-height: 1.25; letter-spacing: -0.
   align-items: center;
   justify-content: center;
   width: 100%;
-  min-height: 0;
-  padding: 0;
+  min-height: auto;
+  padding: 12px 20px 52px;
   overflow: visible;
   transform-origin: center center;
-  will-change: transform;
 }
 .feat-row__visual img {
   display: block;
@@ -499,7 +500,7 @@ h3 { font-size: clamp(20px, 2.2vw, 24px); line-height: 1.25; letter-spacing: -0.
 }
 .band--dark .feat-row__visual img { filter: drop-shadow(0 30px 60px rgba(0, 0, 0, 0.5)); }
 .feat-row__visual--pair {
-  padding: 4px 0 8px;
+  padding: 12px 8px 52px;
 }
 .feat-row--stack .feat-pair {
   width: min(1180px, 100%);
@@ -537,11 +538,18 @@ h3 { font-size: clamp(20px, 2.2vw, 24px); line-height: 1.25; letter-spacing: -0.
   .feat-row--reverse.feat-row--portrait {
     grid-template-columns: 1fr;
     text-align: center;
-    gap: clamp(22px, 4vw, 36px);
+    gap: clamp(16px, 3vw, 28px);
   }
   .feat-row--reverse .feat-row__copy,
   .feat-row--reverse .feat-row__visual { order: unset; }
   .feat-row__copy .lead { margin-inline: auto; }
+  .feat-row__visual {
+    padding: 8px 12px 48px;
+  }
+  .feat-row__visual img,
+  .feat-row__visual--pair img {
+    filter: drop-shadow(0 14px 18px rgba(0, 0, 0, 0.22));
+  }
   .feat-row__visual img.is-portrait {
     max-width: min(320px, 68vw);
     max-height: min(68vh, 560px);

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -244,28 +244,42 @@
         });
       }
       if (visual) {
-        gsap.fromTo(
-          visual,
-          {
+        const shots = visual.querySelectorAll("img");
+        const targets = shots.length ? shots : [visual];
+        // Don't transform the visual wrapper — iOS clips filter:drop-shadow
+        // on a child when the parent has a transform.
+        if (nativeMobileScroll) {
+          gsap.from(targets, {
             opacity: 0,
-            x: stacked ? 0 : fromLeft ? 48 : -48,
-            y: stacked ? 32 : 28,
-            rotate: stacked ? 0 : restRot + (fromLeft ? 5 : -5),
-            scale: stacked ? 0.96 : 0.92,
-          },
-          {
-            opacity: 1,
-            x: 0,
-            y: 0,
-            rotate: restRot,
-            scale: 1,
-            duration: 1.05,
-            ease: "expo.out",
-            scrollTrigger: { trigger: sec, start: "top 80%" },
-          }
-        );
-        if (!nativeMobileScroll) {
-          gsap.to(visual, {
+            y: 18,
+            duration: 0.7,
+            ease: "power3.out",
+            stagger: 0.06,
+            scrollTrigger: { trigger: sec, start: "top 82%" },
+          });
+        } else {
+          gsap.fromTo(
+            targets,
+            {
+              opacity: 0,
+              x: stacked ? 0 : fromLeft ? 48 : -48,
+              y: stacked ? 32 : 28,
+              rotate: stacked ? 0 : restRot + (fromLeft ? 5 : -5),
+              scale: stacked ? 0.96 : 0.92,
+            },
+            {
+              opacity: 1,
+              x: 0,
+              y: 0,
+              rotate: restRot,
+              scale: 1,
+              duration: 1.05,
+              ease: "expo.out",
+              stagger: 0.08,
+              scrollTrigger: { trigger: sec, start: "top 80%" },
+            }
+          );
+          gsap.to(targets, {
             yPercent: -5,
             ease: "none",
             scrollTrigger: {


### PR DESCRIPTION
## What & why

On mobile, feature-row phone stills clipped in two ways:

- The soft drop-shadow was cut off under the device (especially Face Tracking).
- On first load, the bottom of the bezel was sliced — a transform on the wrapper plus `filter: drop-shadow` on the image is an iOS clip.

Animate the images instead of the wrapper, give the visual padding for the glow, and keep mobile entrance to a simple fade/rise (no scale/rotate).

## TestFlight notes

Landing-page CSS/JS only. No tester-facing app behavior.

## Checklist

- [x] `just site-check` passes.
- [x] Conventional Commits.