### PR TITLE
docs: publish the protocol handbook at /docs/

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -4,7 +4,8 @@ body:
     attributes:
       value: |
         Ask away! Before posting, please check existing Q&A discussions to see if
-        your question has already been answered.
+        your question has already been answered. Wire-level BLE, Wi-Fi, and DUML
+        notes live in the [protocol handbook](https://openpocketcine.app/docs/).
 
         Found a bug? Open a GitHub Issue instead of a discussion.
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,10 @@
 blank_issues_enabled: false
 
 contact_links:
+  - name: Protocol handbook
+    url: https://openpocketcine.app/docs/
+    about: BLE pairing, camera Wi-Fi, and DUML as implemented in OpenPocketCine.
+
   - name: Security vulnerability
     url: https://github.com/erik-sutton95/OpenPocketCine/security/advisories/new
     about: Please report security issues privately, not as public issues.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,6 +15,7 @@
           - "Sources/OpenPocketViewCore/Ble*.swift"
           - "Sources/OpenPocketViewCore/Connection*.swift"
           - "docs/protocol-notes.md"
+          - "handbook/**/*"
           - "tools/**/*"
 
 "area:ios":
@@ -72,6 +73,7 @@
           - ".github/**/*"
           - "README.md"
           - "CONTRIBUTING.md"
+          - "handbook/**/*"
 
 "area:android":
   - changed-files:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       android: ${{ steps.filter.outputs.android }}
+      handbook: ${{ steps.filter.outputs.handbook }}
     steps:
       # `dorny/paths-filter` fetches the base ref to diff on push events, which needs the checkout's
       # git credentials — so this job keeps them (unlike the others). It runs no repository code, so
@@ -125,6 +126,10 @@ jobs:
               - 'scripts/android-*.sh'
               - 'justfile'
               - '.github/workflows/ci.yml'
+            handbook:
+              - 'handbook/**'
+              - 'scripts/stage-pages.sh'
+              - '.github/workflows/deploy-pages.yml'
 
   native:
     name: Native Swift/iOS
@@ -179,14 +184,37 @@ jobs:
           SWIFT_ANDROID_SDK_ID: swift-6.3.3-RELEASE_android
         run: ./gradlew assembleDebug test lint
 
+  handbook:
+    name: Protocol handbook
+    needs: changes
+    if: ${{ needs.changes.outputs.handbook == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: handbook/package-lock.json
+      - name: Install handbook dependencies
+        run: npm --prefix handbook ci
+      - name: Build handbook at /docs/
+        env:
+          ASTRO_TELEMETRY_DISABLED: "1"
+          HANDBOOK_BASE: /docs
+        run: npm --prefix handbook run build
+
   gate:
     name: CI gate
-    # The single required status check on `main` (name must stay "CI gate"). `native` and
-    # `android` are conditional, and a required check that never reports leaves a pull request
-    # blocked forever — so this job always runs and collapses every other job's result into
-    # one verdict. Skipped native/android while the repository is still private is success.
+    # The single required status check on `main` (name must stay "CI gate"). `native`,
+    # `android`, and `handbook` are conditional, and a required check that never reports
+    # leaves a pull request blocked forever — so this job always runs and collapses every
+    # other job's result into one verdict. Skipped native/android while the repository is
+    # still private is success.
     if: always()
-    needs: [meta, secrets, changes, native, android]
+    needs: [meta, secrets, changes, native, android, handbook]
     runs-on: ubuntu-latest
     steps:
       - name: Require every job to have passed or been deliberately skipped

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,13 +1,15 @@
-name: Deploy landing page
+name: Deploy GitHub Pages
 
-# Deploys ONLY the public landing page (site/) to GitHub Pages via the
-# "GitHub Actions" Pages source. The shared docs/ folder is NEVER uploaded.
+# Landing page (site/) plus the Starlight handbook at /docs/. Engineering notes
+# in docs/ are never uploaded.
 on:
   push:
     branches: [main]
     paths:
       - "site/**"
+      - "handbook/**"
       - "scripts/check-site.sh"
+      - "scripts/stage-pages.sh"
       - ".github/workflows/deploy-pages.yml"
   workflow_dispatch:
 
@@ -43,8 +45,17 @@ jobs:
             find site -name '*.html' -exec sed -i "s#TESTFLIGHT_URL#${TESTFLIGHT_URL}#g" {} +
           fi
 
-      - name: Verify deploy tree
+      - name: Verify landing-page tree
         run: ./scripts/check-site.sh --deployed
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: handbook/package-lock.json
+
+      - name: Stage landing page and handbook
+        run: ./scripts/stage-pages.sh public-site
 
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
@@ -52,7 +63,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          path: site
+          path: public-site
 
       - name: Deploy to GitHub Pages
         id: deploy

--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,9 @@ handbook/node_modules/
 handbook/dist/
 handbook/.astro/
 
+# Staged GitHub Pages tree (landing + handbook build)
+public-site/
+
 # Python
 __pycache__/
 *.pyc

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,6 @@
+# Starlight in-content links are site routes (../ble/, ./protocol/wifi/), not files.
+handbook/src/content/docs
+handbook/node_modules
+handbook/dist
+handbook/.astro
+public-site

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,9 @@ Install local tooling with `just setup` (macOS / Homebrew).
 - `captures/` — **gitignored.** Packet captures; never commit.
 - `docs/` — engineering references. Start with `commit-hygiene.md`.
 - `handbook/` — Astro Starlight protocol handbook (BLE, Wi-Fi, DUML). Preview with
-  `just handbook`. Markdown in `handbook/src/content/docs/` is the source; it is
-  not on GitHub Pages yet.
+  `just handbook`. Markdown in `handbook/src/content/docs/` is the source. Shipped
+  at [openpocketcine.app/docs](https://openpocketcine.app/docs/) (GitHub Pages
+  merges it next to `site/`).
 - `site/` — GitHub Pages landing page.
 - `.github/` — CI workflows, issue/PR templates.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
-- Local Starlight protocol handbook (`just handbook`) for BLE pairing, camera
-  Wi-Fi, and DUML. Markdown lives in `handbook/src/content/docs/`. Not on GitHub
-  Pages yet.
+- Starlight protocol handbook for BLE pairing, camera Wi-Fi, and DUML at
+  [openpocketcine.app/docs](https://openpocketcine.app/docs/) (`just handbook`
+  locally). Markdown lives in `handbook/src/content/docs/`.
 - **Face Priority** on the Auto EV sheet. On: the drum is grayed, EV follows
   faces to middle gray (median of several; fast third-stops for 2.5 s after a
   face appears, then one third-stop every 1 s), and a face mark sits on the EV

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,9 @@ engineering. By participating you agree to our [Code of Conduct](CODE_OF_CONDUCT
 3. Run `just check` to confirm a green baseline.
 
 No vendor SDK is included or required — the camera protocol is reverse-engineered from public
-behavior (see [`docs/protocol-notes.md`](docs/protocol-notes.md); preview the handbook with
-`just handbook`). **Never commit packet captures,
+behavior (see [`docs/protocol-notes.md`](docs/protocol-notes.md) and
+[openpocketcine.app/docs](https://openpocketcine.app/docs/); `just handbook` locally).
+**Never commit packet captures,
 Wi-Fi passwords, or unofficial LUT dumps.** Official Rec.709 cubes in
 `ios/OpenPocketCine/Resources/` are part of the app. See
 [`docs/commit-hygiene.md`](docs/commit-hygiene.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,9 @@ Frame.io upload is **disabled unless you configure it**. Copy
 - **Bugs only** — Open [GitHub's bug-report form](https://github.com/erik-sutton95/OpenPocketCine/issues/new?template=bug_report.yml).
   New bugs are automatically labeled `needs-triage`; issues are strictly for bugs. Never put
   sensitive information (camera Wi-Fi passwords, captures, credentials) in an issue.
+- **Protocol questions** — Read the
+  [protocol handbook](https://openpocketcine.app/docs/) first, then ask in
+  [Q&A](https://github.com/erik-sutton95/OpenPocketCine/discussions/new?category=q-a).
 - **Feature ideas, enhancements & discussions** — Use **GitHub Discussions**. Start a new
   discussion in the
   [Ideas](https://github.com/erik-sutton95/OpenPocketCine/discussions/new?category=ideas)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # OpenPocketCine
 
 [![CI](https://github.com/erik-sutton95/OpenPocketCine/actions/workflows/ci.yml/badge.svg)](https://github.com/erik-sutton95/OpenPocketCine/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-openpocketcine.app%2Fdocs-blue)](https://openpocketcine.app/docs/)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 <p align="center">
@@ -19,6 +20,8 @@
   <a href="https://testflight.apple.com/join/1tmt3aEB"><strong>Join the TestFlight</strong></a>
   &nbsp;·&nbsp;
   <a href="https://openpocketcine.app/">Visit openpocketcine.app</a>
+  &nbsp;·&nbsp;
+  <a href="https://openpocketcine.app/docs/">Protocol handbook</a>
   &nbsp;·&nbsp;
   <a href="https://github.com/erik-sutton95/OpenPocketCine/discussions/29">Explore the roadmap</a>
 </p>
@@ -142,6 +145,13 @@ lives in [`docs/ROADMAP.md`](docs/ROADMAP.md).
 No subscriptions, no paywalls, no advertising, and no telemetry. OpenPocketCine is Apache-2.0
 licensed and built in public with the latest frontier models — Grok, Codex, and Claude — so
 filmmakers and developers can inspect, improve, and adapt the tool they rely on.
+
+## Documentation
+
+- **[Protocol handbook](https://openpocketcine.app/docs/)** — BLE pairing, camera Wi-Fi, DUML
+  frames, commands, and live view. Preview locally with `just handbook`.
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — shared Swift core and platform shells
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — setup, workflow, and how to report bugs
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Tooling is managed through [`just`](https://github.com/casey/just):
 ```bash
 just setup         # install meta-check tools (macOS / Homebrew)
 just               # list all recipes
-just handbook      # protocol handbook at http://127.0.0.1:4321/
+just handbook      # protocol handbook at http://127.0.0.1:4321/ (live: https://openpocketcine.app/docs/)
 just check         # run repository quality checks
 just format        # format Swift sources
 just test          # run Swift package tests

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -32,7 +32,9 @@ Osmosis source is included in or distributed with OpenPocketCine. Live view, mon
 native shells are our own work.
 
 No DJI SDK or proprietary DJI documentation is included in, distributed with, or required by this
-project (see [NOTICE](NOTICE) and [`docs/protocol-notes.md`](docs/protocol-notes.md)).
+project (see [NOTICE](NOTICE), the
+[protocol handbook](https://openpocketcine.app/docs/), and
+[`docs/protocol-notes.md`](docs/protocol-notes.md)).
 
 ## Official DJI Rec.709 cubes
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,4 +24,5 @@ The iOS Xcode project is generated: `cd ios && xcodegen generate`.
 Platform shells own sockets, permissions, lifecycle, rendering, storage, and UI. Keep that
 boundary: do not import SwiftUI into the core.
 
-See [`protocol-notes.md`](protocol-notes.md) for wire-level detail.
+See the [protocol handbook](https://openpocketcine.app/docs/) for wire-level detail
+(Markdown source in `handbook/src/content/docs/`; stub at [`protocol-notes.md`](protocol-notes.md)).

--- a/docs/capture-guide.md
+++ b/docs/capture-guide.md
@@ -3,9 +3,10 @@
 Packet captures of camera traffic stay in gitignored `captures/`. Never commit
 pcaps, SoftAP passwords, BLE HCI snoop logs, or unofficial LUT dumps.
 
-Protocol facts that are confirmed on hardware belong in
-[`protocol-notes.md`](protocol-notes.md). Implementation lives in
-`Sources/OpenPocketViewCore/`.
+Protocol facts that are confirmed on hardware belong in the
+[protocol handbook](https://openpocketcine.app/docs/) (source in
+`handbook/src/content/docs/`; stub at [`protocol-notes.md`](protocol-notes.md)).
+Implementation lives in `Sources/OpenPocketViewCore/`.
 
 Offline helpers on your machine (they read gitignored captures; they are not a
 how-to for intercepting another app):

--- a/docs/commit-hygiene.md
+++ b/docs/commit-hygiene.md
@@ -41,8 +41,8 @@ re-run the checklist.
   Route contact through GitHub-native channels (Security Advisories, maintainer profiles).
 - **Vendor / proprietary protocol material.** Any vendor SDK, specification PDF, header, binary, or
   network capture (`*.pcap`, `*.pcapng`). Protocol facts must be attributable to public sources in
-  [`protocol-notes.md`](protocol-notes.md) (handbook pages in `handbook/src/content/docs/`) and
-  hardware observation — never pasted from proprietary
+  the [protocol handbook](https://openpocketcine.app/docs/)
+  (`handbook/src/content/docs/`) and hardware observation — never pasted from proprietary
   DJI documentation.
 - **Unofficial LUT dumps.** The bundled official Rec.709 cubes under
   `ios/OpenPocketCine/Resources/` are redistributable and tracked. Copies under `Osmo LUTS/`

--- a/docs/protocol-notes.md
+++ b/docs/protocol-notes.md
@@ -1,8 +1,9 @@
 # Protocol notes
 
 Human-readable protocol handbook (BLE, camera Wi-Fi, DUML) lives in
-[`handbook/src/content/docs/`](../handbook/src/content/docs/). Preview locally
-with `just handbook` (http://localhost:4321/). It is not on GitHub Pages yet.
+[`handbook/src/content/docs/`](../handbook/src/content/docs/). Read it at
+[openpocketcine.app/docs](https://openpocketcine.app/docs/). Preview locally
+with `just handbook` (http://localhost:4321/).
 
 OpenPocketCine is not affiliated with DJI. No DJI SDK or confidential spec is in
 this repo. Packet captures stay in gitignored `captures/` and are never

--- a/docs/repository-settings.md
+++ b/docs/repository-settings.md
@@ -29,7 +29,8 @@ iOS and Android jobs skip while the repository is private (paid macOS minutes)
 and run once it is public. The **CI gate** job is the merge gate even when
 those jobs are skipped.
 
-The landing-page workflow deploys only `site/` to GitHub Pages. The PR labeler
+The Pages workflow deploys `site/` (landing) plus the Starlight handbook at
+`/docs/`. Engineering notes in `docs/` are never uploaded. The PR labeler
 uses `pull_request_target` and does **not** check out pull-request code.
 
 ## Security

--- a/handbook/README.md
+++ b/handbook/README.md
@@ -4,15 +4,17 @@ Astro [Starlight](https://starlight.astro.build/) site for the OpenPocketCine
 camera protocol (BLE, SoftAP, DUML). Markdown in `src/content/docs/` is the
 source of truth for both the local site and agent tooling.
 
-Preview from the repository root (does not deploy anything):
+Published at [openpocketcine.app/docs](https://openpocketcine.app/docs/).
+Preview from the repository root:
 
 ```bash
 just handbook
 ```
 
-Then open [http://localhost:4321/](http://localhost:4321/). This is not wired to GitHub Pages yet.
+Then open [http://localhost:4321/](http://localhost:4321/).
 
 | Command | Action |
 | --- | --- |
-| `just handbook` | Dev server |
-| `just handbook-build` | Production build to `handbook/dist/` (local check only) |
+| `just handbook` | Dev server (site root, no `/docs/` prefix) |
+| `just handbook-build` | Production build to `handbook/dist/` |
+| `just handbook-stage` | Merge landing + handbook into `public-site/` as Pages will ship it |

--- a/handbook/astro.config.mjs
+++ b/handbook/astro.config.mjs
@@ -2,10 +2,14 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 
-// Local preview uses the site root (`just handbook` → http://localhost:4321/).
-// A `/docs/` base path is only needed if this is later merged into GitHub Pages.
+// Local preview (`just handbook`) is the site root. GitHub Pages serves the
+// handbook under /docs/ — set HANDBOOK_BASE=/docs for that build.
+const handbookBase = process.env.HANDBOOK_BASE || '/';
+
 export default defineConfig({
   site: 'https://openpocketcine.app',
+  base: handbookBase,
+  trailingSlash: 'always',
   integrations: [
     starlight({
       title: 'OpenPocketCine',
@@ -15,7 +19,7 @@ export default defineConfig({
         src: './src/assets/icon.png',
         alt: 'OpenPocketCine',
       },
-      favicon: '/favicon.png',
+      favicon: 'favicon.png',
       social: [
         {
           icon: 'github',

--- a/handbook/src/content/docs/index.mdx
+++ b/handbook/src/content/docs/index.mdx
@@ -29,12 +29,12 @@ BLE scan → GATT connect → app-pairing → read Wi-Fi creds → join AP → U
 
 ## Pages
 
-- [Connection spine](./protocol/connection.md) — order of operations
-- [BLE pairing](./protocol/ble.md) — scan, GATT, app-level pairing
-- [Camera Wi-Fi](./protocol/wifi.md) — credentials over BLE, SoftAP join
-- [DUML frame](./protocol/duml-frame.md) — `0x55` framing and CRCs
-- [DUML transport](./protocol/duml-transport.md) — UDP 9004, TCP poke, wrapping headers
-- [Command catalog](./protocol/commands.md) — set/cmd table
-- [Live view](./protocol/live-view.md) — enable, HEVC/AVC, fragments
-- [HTTP media](./protocol/media.md) — SoftAP `/v2` fetch, list, delete, star
-- [iOS notes](./protocol/ios.md) — Hotspot Configuration, Local Network, Simulator
+- [Connection spine](./protocol/connection/) — order of operations
+- [BLE pairing](./protocol/ble/) — scan, GATT, app-level pairing
+- [Camera Wi-Fi](./protocol/wifi/) — credentials over BLE, SoftAP join
+- [DUML frame](./protocol/duml-frame/) — `0x55` framing and CRCs
+- [DUML transport](./protocol/duml-transport/) — UDP 9004, TCP poke, wrapping headers
+- [Command catalog](./protocol/commands/) — set/cmd table
+- [Live view](./protocol/live-view/) — enable, HEVC/AVC, fragments
+- [HTTP media](./protocol/media/) — SoftAP `/v2` fetch, list, delete, star
+- [iOS notes](./protocol/ios/) — Hotspot Configuration, Local Network, Simulator

--- a/handbook/src/content/docs/protocol/ble.md
+++ b/handbook/src/content/docs/protocol/ble.md
@@ -3,7 +3,7 @@ title: BLE pairing
 description: Scan, GATT, and app-level pairing for Osmo Pocket cameras.
 ---
 
-BLE is control only. After pairing, Wi-Fi credentials are read over GATT and bulk data moves to the camera SoftAP. See the [connection spine](./connection.md).
+BLE is control only. After pairing, Wi-Fi credentials are read over GATT and bulk data moves to the camera SoftAP. See the [connection spine](../connection/).
 
 ## Scan
 
@@ -46,4 +46,4 @@ Send `SetPairingPIN` (`0x07/0x45`), payload `packString(identifier) + packString
 
 First-time approval arrives as a `0x07/0x46` **request** — ACK it with a response frame.
 
-Commands are in the [catalog](./commands.md). Frame format is [DUML](./duml-frame.md).
+Commands are in the [catalog](../commands/). Frame format is [DUML](../duml-frame/).

--- a/handbook/src/content/docs/protocol/commands.md
+++ b/handbook/src/content/docs/protocol/commands.md
@@ -3,7 +3,7 @@ title: Command catalog
 description: DUML set/cmd values used on the connection spine, camera control, media, and live view.
 ---
 
-Commands we know for the connection spine, status, camera control, media, and live view. Framing is in [DUML frame](./duml-frame.md). This is not a complete vendor dictionary — only what OpenPocketCine has confirmed.
+Commands we know for the connection spine, status, camera control, media, and live view. Framing is in [DUML frame](../duml-frame/). This is not a complete vendor dictionary — only what OpenPocketCine has confirmed.
 
 | set/cmd | meaning | notes |
 |---|---|---|
@@ -19,7 +19,7 @@ Commands we know for the connection spine, status, camera control, media, and li
 | `0x00/0x27` | media list chunks | `[10B sub][chunk]`; subtype `01` is data. Concat in arrival order → CompositePack. |
 | `0x00/0x28` | delete media | `[count][handle:u32][counter:u32] 00 [count:u32] 01 01 00 00`. Do not re-send. |
 | `0x02/0xBF` | favorite / star | `01 01 [handle][counter] 00 [on] 00 00 00`. Nano star byte `== 1` only. |
-| HTTP `/v2` | SoftAP file fetch | See [HTTP media](./media.md). |
+| HTTP `/v2` | SoftAP file fetch | See [HTTP media](../media/). |
 | `0x0d/0x02` | **battery push** | percent at payload offset 20 |
 | `0x02/0xdc` | **storage push** | SD + internal capacity/free |
 | `0x02/0x80` | active-store + playback bit | unsolicited |

--- a/handbook/src/content/docs/protocol/connection.md
+++ b/handbook/src/content/docs/protocol/connection.md
@@ -9,12 +9,12 @@ BLE is control only; bulk data goes over Wi-Fi. Order of operations:
 BLE scan → GATT connect → app-pairing → read Wi-Fi creds → join AP → UDP DUML → HTTP media
 ```
 
-1. **[BLE scan](./ble.md).** Identify the camera from manufacturer data or name. No scan filter (Pocket 3 omits manufacturer data).
-2. **[GATT](./ble.md).** Service `fff0`; notify on `fff4`, write commands to `fff5`. Request MTU 517. Pace writes.
-3. **[App-level pairing](./ble.md).** Replaces BT bonding. `SetPairingPIN` (`0x07/0x45`); first-time approval is `0x07/0x46`.
-4. **[Wi-Fi credentials](./wifi.md).** `GetWifiSsid` (`0x07/0x07`) then `GetWifiPassword` (`0x07/0x0e`). Do not synthesize the passphrase.
-5. **[Join the AP](./wifi.md).** Phone joins the camera SoftAP (WPA2). Camera/gateway is `192.168.2.1`.
-6. **[UDP DUML](./duml-transport.md).** Port **9004** for the Pocket family, after a TCP `:7001` poke. Then handshake, register, subscribe.
-7. **[HTTP media](./media.md)** and **[live view](./live-view.md)** ride that LAN.
+1. **[BLE scan](../ble/).** Identify the camera from manufacturer data or name. No scan filter (Pocket 3 omits manufacturer data).
+2. **[GATT](../ble/).** Service `fff0`; notify on `fff4`, write commands to `fff5`. Request MTU 517. Pace writes.
+3. **[App-level pairing](../ble/).** Replaces BT bonding. `SetPairingPIN` (`0x07/0x45`); first-time approval is `0x07/0x46`.
+4. **[Wi-Fi credentials](../wifi/).** `GetWifiSsid` (`0x07/0x07`) then `GetWifiPassword` (`0x07/0x0e`). Do not synthesize the passphrase.
+5. **[Join the AP](../wifi/).** Phone joins the camera SoftAP (WPA2). Camera/gateway is `192.168.2.1`.
+6. **[UDP DUML](../duml-transport/).** Port **9004** for the Pocket family, after a TCP `:7001` poke. Then handshake, register, subscribe.
+7. **[HTTP media](../media/)** and **[live view](../live-view/)** ride that LAN.
 
 Implementation lives in `Sources/OpenPocketViewCore/`. Platform shells own sockets, permissions, and the Wi-Fi join.

--- a/handbook/src/content/docs/protocol/duml-frame.md
+++ b/handbook/src/content/docs/protocol/duml-frame.md
@@ -20,7 +20,7 @@ Format and CRCs are in `Sources/OpenPocketViewCore/DumlFrame.swift` (self-tested
 | sender / receiver | device addresses |
 | seq | `u16` little-endian |
 | flags | see below |
-| set / cmd | command identity; see the [catalog](./commands.md) |
+| set / cmd | command identity; see the [catalog](../commands/) |
 | payload | command-specific |
 | crc16 | `u16` little-endian |
 
@@ -32,4 +32,4 @@ Format and CRCs are in `Sources/OpenPocketViewCore/DumlFrame.swift` (self-tested
 | `0xC0` | response |
 | `0x00` | notify |
 
-On the UDP datalink each frame is wrapped in extra headers. See [DUML transport](./duml-transport.md). The pcap tool sidesteps that wrapping by scanning for CRC-valid frames.
+On the UDP datalink each frame is wrapped in extra headers. See [DUML transport](../duml-transport/). The pcap tool sidesteps that wrapping by scanning for CRC-valid frames.

--- a/handbook/src/content/docs/protocol/duml-transport.md
+++ b/handbook/src/content/docs/protocol/duml-transport.md
@@ -3,7 +3,7 @@ title: DUML transport
 description: TCP :7001 poke, UDP port 9004, handshake, and wrapping headers.
 ---
 
-After the phone has joined the camera [SoftAP](./wifi.md), control and live view share a UDP datalink. Framing is still [DUML](./duml-frame.md); transport adds wrapping headers.
+After the phone has joined the camera [SoftAP](../wifi/), control and live view share a UDP datalink. Framing is still [DUML](../duml-frame/); transport adds wrapping headers.
 
 ## Arm the datalink
 
@@ -25,6 +25,6 @@ Then a 40-byte UDP handshake, then register + subscribe.
 
 On the UDP datalink each DUML frame is wrapped in an **8-byte transport header** + **12-byte routing header**. OpenPocketCine’s pcap tool sidesteps that by scanning for CRC-valid `0x55` frames.
 
-Live view is **not** a separate port. Video is datalink `pktType 0x02` on the same UDP 9004 socket. See [live view](./live-view.md).
+Live view is **not** a separate port. Video is datalink `pktType 0x02` on the same UDP 9004 socket. See [live view](../live-view/).
 
 Transport parsing lives in `Sources/OpenPocketViewCore/DumlTransport.swift`.

--- a/handbook/src/content/docs/protocol/ios.md
+++ b/handbook/src/content/docs/protocol/ios.md
@@ -11,4 +11,4 @@ Compared with Osmosis on Android:
 - **No MAC/OUI over CoreBluetooth** — the Xtra-by-OUI detection and per-MAC password cache in Osmosis must key off the BLE name / peripheral UUID instead.
 - **Pace `fff5` writes** with `.withoutResponse` + delays, same as Android.
 
-See [BLE pairing](./ble.md) and [camera Wi-Fi](./wifi.md).
+See [BLE pairing](../ble/) and [camera Wi-Fi](../wifi/).

--- a/handbook/src/content/docs/protocol/live-view.md
+++ b/handbook/src/content/docs/protocol/live-view.md
@@ -16,7 +16,7 @@ Nano uses the same DJI `00 00 01 ff` marker and fragment layout; SPS `67 64 00 1
 
 ## Transport
 
-The video is on the [DUML datalink](./duml-transport.md) itself — **UDP port 9004**, carried as datalink **pktType `0x02`** packets. It is *not* on a separate port or protocol.
+The video is on the [DUML datalink](../duml-transport/) itself — **UDP port 9004**, carried as datalink **pktType `0x02`** packets. It is *not* on a separate port or protocol.
 
 ## Enable
 

--- a/handbook/src/content/docs/protocol/media.md
+++ b/handbook/src/content/docs/protocol/media.md
@@ -3,7 +3,7 @@ title: HTTP media
 description: SoftAP /v2 file fetch, media list, delete, and favorite/star.
 ---
 
-Once the phone is on the camera [SoftAP](./wifi.md), stills and clips are fetched over HTTP. Listing, delete, and star stay on [DUML](./commands.md).
+Once the phone is on the camera [SoftAP](../wifi/), stills and clips are fetched over HTTP. Listing, delete, and star stay on [DUML](../commands/).
 
 ## File fetch
 

--- a/handbook/src/content/docs/protocol/wifi.md
+++ b/handbook/src/content/docs/protocol/wifi.md
@@ -3,7 +3,7 @@ title: Camera Wi-Fi
 description: Read SoftAP credentials over BLE and join the camera access point.
 ---
 
-After [app-level pairing](./ble.md), the camera exposes its own access point. The phone joins that SoftAP; DUML and HTTP then use the camera LAN.
+After [app-level pairing](../ble/), the camera exposes its own access point. The phone joins that SoftAP; DUML and HTTP then use the camera LAN.
 
 ## Credentials over BLE
 
@@ -27,6 +27,6 @@ Phone joins the camera's SoftAP (WPA2).
 | Camera / gateway | `192.168.2.1` |
 | Phone | `192.168.2.x`/24 |
 
-On iOS this is `NEHotspotConfiguration` (Hotspot Configuration entitlement). See [iOS notes](./ios.md). SoftAP helpers live in `Sources/OpenPocketViewCore/CameraSoftAP.swift`.
+On iOS this is `NEHotspotConfiguration` (Hotspot Configuration entitlement). See [iOS notes](../ios/). SoftAP helpers live in `Sources/OpenPocketViewCore/CameraSoftAP.swift`.
 
-Once associated, open the [UDP DUML datalink](./duml-transport.md).
+Once associated, open the [UDP DUML datalink](../duml-transport/).

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -9,7 +9,7 @@ New and changed
 
 Fixes
 
-- This build has no new app behavior. Keep testing Face Priority, shutter angle, and reconnect.
+- This build has no new app behavior — keep testing Face Priority, shutter angle, and reconnect.
 - Traffic Lights crush/clip compensation starts at 0 stops. Long-press LIGHTS if you want the old ¼-stop tolerance.
 - First connect no longer sits on Waiting for live-view when a few video packets arrive and then freeze.
 - While a subject is tracked, stick left/right matches the free gimbal instead of reversing.

--- a/justfile
+++ b/justfile
@@ -39,7 +39,7 @@ lint-md:
 # The GitHub Pages landing page is validated by `site-check` instead.
 # handbook/node_modules and build output are generated; skip them.
 check-links:
-    lychee --no-progress --offline --exclude-path vendor --exclude-path ref --exclude-path docs/design --exclude-path site --exclude-path handbook/node_modules --exclude-path handbook/dist --exclude-path handbook/.astro .
+    lychee --no-progress --offline --exclude-path vendor --exclude-path ref --exclude-path docs/design --exclude-path site .
 
 # Verify files obey .editorconfig.
 check-editorconfig:
@@ -132,8 +132,8 @@ run:
 clean:
     swift package clean
 
-# ── Protocol handbook (Astro Starlight; local preview only) ────────────────
-# Serves http://localhost:4321/. Not deployed to GitHub Pages yet.
+# ── Protocol handbook (Astro Starlight) ────────────────────────────────────
+# Local preview at http://localhost:4321/. Production is /docs/ on Pages.
 
 handbook:
     #!/usr/bin/env bash
@@ -149,7 +149,11 @@ handbook-build:
     if [[ ! -d handbook/node_modules ]]; then
         npm --prefix handbook ci
     fi
-    ASTRO_TELEMETRY_DISABLED=1 npm --prefix handbook run build
+    ASTRO_TELEMETRY_DISABLED=1 HANDBOOK_BASE="${HANDBOOK_BASE:-}" npm --prefix handbook run build
+
+# Merge landing page + handbook into public-site/ as GitHub Pages will ship it.
+handbook-stage:
+    ./scripts/stage-pages.sh public-site
 
 # ── Android production stack ────────────────────────────────────────────────
 # JAVA_HOME falls back to the Homebrew OpenJDK so recipes work without shell setup.

--- a/scripts/stage-pages.sh
+++ b/scripts/stage-pages.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Merge the landing page (site/) with a /docs/ Starlight build for GitHub Pages.
+# Does not modify site/ or commit the result.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+dest="${1:-"$root/public-site"}"
+
+rm -rf "$dest"
+mkdir -p "$dest"
+cp -a "$root/site/." "$dest/"
+
+if [[ ! -d "$root/handbook/node_modules" ]]; then
+  npm --prefix "$root/handbook" ci
+fi
+ASTRO_TELEMETRY_DISABLED=1 HANDBOOK_BASE=/docs npm --prefix "$root/handbook" run build
+
+mkdir -p "$dest/docs"
+if [[ -d "$root/handbook/dist/docs" ]]; then
+  cp -a "$root/handbook/dist/docs/." "$dest/docs/"
+else
+  cp -a "$root/handbook/dist/." "$dest/docs/"
+fi
+touch "$dest/.nojekyll"
+
+if ! grep -q '/docs/' "$dest/docs/index.html"; then
+  echo "Handbook production build is missing the /docs/ base path." >&2
+  exit 1
+fi
+
+if [[ ! -f "$dest/CNAME" ]]; then
+  echo "Staged tree is missing site/CNAME." >&2
+  exit 1
+fi

--- a/site/index.html
+++ b/site/index.html
@@ -42,6 +42,7 @@
         <a href="#tracking">Tracking</a>
         <a href="#vertical">Assists</a>
         <a href="#media">Media</a>
+        <a href="/docs/">Docs</a>
         <a href="/support/">Support</a>
         <a href="#open-source">Open Source</a>
       </nav>
@@ -201,7 +202,7 @@
         <p class="lead">No subscriptions, no paywalls, no telemetry. OpenPocketCine is Apache-2.0 licensed and built in the open by a community of filmmakers and developers.</p>
         <div class="hero__cta">
           <a class="btn btn--primary btn--magnetic" href="https://github.com/erik-sutton95/OpenPocketCine" target="_blank" rel="noopener"><span class="btn__rec" aria-hidden="true"></span>★ Star on GitHub</a>
-          <a class="btn btn--ghost btn--magnetic" href="https://github.com/erik-sutton95/OpenPocketCine" target="_blank" rel="noopener">Contribute<span class="btn__arrow" aria-hidden="true">→</span></a>
+          <a class="btn btn--ghost btn--magnetic" href="/docs/">Protocol handbook<span class="btn__arrow" aria-hidden="true">→</span></a>
         </div>
       </div>
     </section>
@@ -273,6 +274,7 @@
         <span>OpenPocketCine</span>
       </div>
       <p class="footer__meta">
+        <a href="/docs/">Docs</a> ·
         <a href="/support/">Support</a> ·
         <a href="/privacy/">Privacy</a> ·
         <a href="/terms/">Terms</a> ·

--- a/site/privacy/index.html
+++ b/site/privacy/index.html
@@ -151,7 +151,7 @@
   <footer class="footer">
     <div class="container footer__inner">
       <div class="footer__brand"><img src="../assets/icon.png" alt="" width="24" height="24"><span>OpenPocketCine</span></div>
-      <p class="footer__meta"><a href="/">Home</a> · <a href="/support/">Support</a> · <a href="/terms/">Terms</a> · <a href="https://github.com/erik-sutton95/OpenPocketCine" target="_blank" rel="noopener">Source</a></p>
+      <p class="footer__meta"><a href="/">Home</a> · <a href="/docs/">Docs</a> · <a href="/support/">Support</a> · <a href="/terms/">Terms</a> · <a href="https://github.com/erik-sutton95/OpenPocketCine" target="_blank" rel="noopener">Source</a></p>
       <p class="footer__disclaimer">OpenPocketCine is not affiliated with or endorsed by SZ DJI Technology Co., Ltd.</p>
     </div>
   </footer>

--- a/site/support/index.html
+++ b/site/support/index.html
@@ -166,7 +166,7 @@
   <footer class="footer">
     <div class="container footer__inner">
       <div class="footer__brand"><img src="../assets/icon.png" alt="" width="24" height="24"><span>OpenPocketCine</span></div>
-      <p class="footer__meta"><a href="/">Home</a> · <a href="/privacy/">Privacy</a> · <a href="/terms/">Terms</a> · <a href="https://github.com/erik-sutton95/OpenPocketCine" target="_blank" rel="noopener">Source</a></p>
+      <p class="footer__meta"><a href="/">Home</a> · <a href="/docs/">Docs</a> · <a href="/privacy/">Privacy</a> · <a href="/terms/">Terms</a> · <a href="https://github.com/erik-sutton95/OpenPocketCine" target="_blank" rel="noopener">Source</a></p>
       <p class="footer__disclaimer">OpenPocketCine is an independent application, not affiliated with or endorsed by SZ DJI Technology Co., Ltd. “DJI”, “Osmo”, and “Osmo Pocket” are trademarks of SZ DJI Technology Co., Ltd., used for identification only.</p>
     </div>
   </footer>

--- a/site/terms/index.html
+++ b/site/terms/index.html
@@ -128,7 +128,7 @@
   <footer class="footer">
     <div class="container footer__inner">
       <div class="footer__brand"><img src="../assets/icon.png" alt="" width="24" height="24"><span>OpenPocketCine</span></div>
-      <p class="footer__meta"><a href="/">Home</a> · <a href="/support/">Support</a> · <a href="/privacy/">Privacy</a> · <a href="https://github.com/erik-sutton95/OpenPocketCine" target="_blank" rel="noopener">Source</a></p>
+      <p class="footer__meta"><a href="/">Home</a> · <a href="/docs/">Docs</a> · <a href="/support/">Support</a> · <a href="/privacy/">Privacy</a> · <a href="https://github.com/erik-sutton95/OpenPocketCine" target="_blank" rel="noopener">Source</a></p>
       <p class="footer__disclaimer">OpenPocketCine is not affiliated with or endorsed by SZ DJI Technology Co., Ltd.</p>
     </div>
   </footer>


### PR DESCRIPTION
## What & why

Follow-up to #102. GitHub Pages now builds the Starlight handbook and serves it at https://openpocketcine.app/docs/ next to the landing page.

- Production build uses `HANDBOOK_BASE=/docs`.
- `scripts/stage-pages.sh` merges `site/` + `handbook/dist/` into `public-site/` (not committed).
- Landing-page CSP/SRI/asset checks still run only on `site/`.
- CI builds the handbook when those paths change.
- Landing nav/footer (and support/privacy/terms) link to `/docs/`.
- Local preview is unchanged: `just handbook` at http://127.0.0.1:4321/.

## TestFlight notes

`justfile` already triggered notes in #102. This PR is still documentation only; no camera or monitor behavior change. `WhatToTest.en-US.txt` is unchanged in this commit.

## Checklist

- [x] `just check` passes.
- [x] Native production changes: none. `just native-check` not required.
- [x] Commits follow Conventional Commits.
- [x] No captures, Wi-Fi passwords, unofficial LUT dumps, signing material, or other secrets.
- [x] Docs/CHANGELOG updated if behavior or setup changed.
- [x] TestFlight-triggering changes include reviewed `ios/TestFlight/WhatToTest.en-US.txt` copy. N/A for this follow-up (justfile recipes already landed in #102; this commit does not change tester copy).
- [x] iOS release PRs: bump `MARKETING_VERSION` — N/A.