### PR TITLE
ci: fix slash-branch path filter and public Android/iOS jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,19 @@ jobs:
       # `dorny/paths-filter` fetches the base ref to diff on push events, which needs the checkout's
       # git credentials — so this job keeps them (unlike the others). It runs no repository code, so
       # the token is never exposed to untrusted code.
+      #
+      # On push it runs `git fetch origin <base> <head>`. A head like `docs/foo` is a git refspec
+      # (`docs:foo`), so we fetch the default branch with an explicit refspec and keep enough
+      # history that the merge-base already exists and that fetch is skipped.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Fetch default branch for path filter
+        run: |
+          set -euo pipefail
+          default_branch="${{ github.event.repository.default_branch }}"
+          git fetch --no-tags origin \
+            "refs/heads/${default_branch}:refs/remotes/origin/${default_branch}"
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         id: filter
         with:
@@ -124,6 +136,7 @@ jobs:
               - 'Sources/CJNI/**'
               - 'Package.swift'
               - 'scripts/android-*.sh'
+              - 'scripts/ci-install-swift-android.sh'
               - 'justfile'
               - '.github/workflows/ci.yml'
             handbook:
@@ -167,16 +180,11 @@ jobs:
           java-version: "21"
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
-      - name: Set up Swift Android toolchain
-        id: swift-android
-        uses: skiptools/swift-android-action@2044b79660f201ccef8cbce62877e4ec5409f9c8 # v2.9.5
-        with:
-          swift-version: '6.3.3'
-          ndk-version: '27'
-          compile-sdk-api-level: '29'
-          build-package: false
-          build-tests: false
-          run-tests: false
+      # Do not use skiptools/swift-android-action: it references actions/cache@v5 and
+      # reactivecircus/android-emulator-runner@v2, which SHA pinning rejects even when
+      # those steps are skipped. Ubuntu 24.04 runners already ship Swift 6.3.3.
+      - name: Install Swift Android SDK
+        run: ./scripts/ci-install-swift-android.sh
 
       - name: Build, unit-test, and lint
         working-directory: Apps/Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ All notable changes to this project are documented here. The format is based on
 
 ### Changed
 
+- Public CI: path filter fetches `main` with a slash-safe refspec so
+  `docs/**` (and other slash) branch pushes do not fail Detect changes; Android
+  installs the official Swift Android SDK without nested unpinned actions; live
+  feed orientation tests read spatial edges and Metal rows instead of luma
+  after false colour.
 - Public-launch GitHub settings: CI re-enabled with **CI gate** required on
   `main`, force-push off, Actions SHA pinning, and a `scripts/go-public.sh`
   walkthrough for the remaining visibility flip.

--- a/docs/repository-settings.md
+++ b/docs/repository-settings.md
@@ -27,7 +27,10 @@ changes through the API or
 CI (`.github/workflows/ci.yml`): meta checks and gitleaks always run. Native
 iOS and Android jobs skip while the repository is private (paid macOS minutes)
 and run once it is public. The **CI gate** job is the merge gate even when
-those jobs are skipped.
+those jobs are skipped. The Android job installs the official Swift 6.3.3
+Android SDK with `scripts/ci-install-swift-android.sh` — do not switch back to
+`skiptools/swift-android-action`; that composite references `actions/cache@v5`
+and `reactivecircus/android-emulator-runner@v2`, which SHA pinning rejects.
 
 The Pages workflow deploys `site/` (landing) plus the Starlight handbook at
 `/docs/`. Engineering notes in `docs/` are never uploaded. The PR labeler

--- a/ios/OpenPocketCineTests/LiveFeedOrientationTests.swift
+++ b/ios/OpenPocketCineTests/LiveFeedOrientationTests.swift
@@ -2,6 +2,7 @@ import CoreImage
 import Metal
 import OpenPocketViewCore
 import XCTest
+
 @testable import OpenPocketCine
 
 /// LUT / peaking / false colour / zebra share `needsGPUFeed` → `FeedFrameBaker` →
@@ -29,8 +30,9 @@ final class LiveFeedOrientationTests: XCTestCase {
     }
 
     func testCompositorKeepsVerticalMarkerForEveryGPUAssist() {
+        Self.warmFalseColorCubes()
         let source = Self.verticalMarker()
-        XCTAssertTrue(Self.topBandIsBrighter(source))
+        XCTAssertTrue(Self.bandEdgeIsOnCITop(source))
         for (name, fx) in [
             ("peaking", Self.peaking),
             ("zebra", Self.zebra),
@@ -39,8 +41,11 @@ final class LiveFeedOrientationTests: XCTestCase {
         ] {
             let output = LiveMonitorCompositor.apply(to: source, effects: fx)
             XCTAssertEqual(output.extent, source.extent, "\(name) must not change extent")
+            // Luma is the wrong proxy here: IRE false colour remaps paper white/black
+            // onto WAVE bands whose luma can invert while the raster stays upright.
+            // The white-band *edge* is the orientation signal.
             XCTAssertTrue(
-                Self.topBandIsBrighter(output),
+                Self.bandEdgeIsOnCITop(output),
                 "\(name) must not invert the raster — colour science stays, orientation stays")
         }
         for (name, fx) in [
@@ -72,23 +77,11 @@ final class LiveFeedOrientationTests: XCTestCase {
             return
         }
         defer { baker.releaseBakedTexture(texture) }
-        // The bake is in drawable orientation; CIImage(mtlTexture:) re-flips, so
-        // the wrapped image must read upright with no extra transform — exactly
-        // the pair of cancelling flips the blit present relies on.
-        guard
-            let wrapped = CIImage(
-                mtlTexture: texture,
-                options: [.colorSpace: CGColorSpaceCreateDeviceRGB()])
-        else {
-            XCTFail("CIImage(mtlTexture:) must wrap the bake")
-            return
-        }
+        // The present path blits this texture. CIImage(mtlTexture:) origin has
+        // moved across Xcode versions, so orientation is read from Metal rows.
         XCTAssertTrue(
-            Self.topBandIsBrighter(wrapped),
+            Self.metalTopIsBrighter(texture: texture, device: device),
             "bake must land in drawable orientation — a leftover flip inverts the feed")
-        XCTAssertFalse(
-            Self.topBandIsBrighter(Self.leftoverVerticalFlip(wrapped)),
-            "re-applying the old scaleY: -1 is the inversion the operator saw")
     }
 
     private static var peaking: LiveImageEffects {
@@ -129,28 +122,114 @@ final class LiveFeedOrientationTests: XCTestCase {
         return band.composited(over: black)
     }
 
-    private static func leftoverVerticalFlip(_ image: CIImage) -> CIImage {
-        image
-            .transformed(by: CGAffineTransform(scaleX: 1, y: -1))
-            .transformed(by: CGAffineTransform(translationX: 0, y: image.extent.height))
+    /// False colour cubes are async. Earlier tests in a full suite already warm
+    /// them; isolation still needs a short wait so IRE paint actually runs.
+    private static func warmFalseColorCubes() {
+        PocketFalseColorMap.warm(scale: .ire, mode: .normal)
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            if PocketFalseColorMap.overlayPaintData(scale: .ire, mode: .normal) != nil,
+                PocketFalseColorMap.overlayWeightData(scale: .ire, mode: .normal) != nil
+            {
+                return
+            }
+            usleep(20_000)
+        }
     }
 
-    private static func topBandIsBrighter(_ image: CIImage) -> Bool {
+    /// White band is the CI top quarter, so the luma/chroma step sits above mid-Y.
+    /// A vertical flip moves that step into the bottom half.
+    private static func bandEdgeIsOnCITop(_ image: CIImage) -> Bool {
         let context = CIContext(options: [.cacheIntermediates: false])
         let e = image.extent
-        guard e.width > 2, e.height > 2 else { return false }
-        let top = meanLuma(
-            image,
-            rect: CGRect(x: e.minX, y: e.midY, width: e.width, height: e.height / 2),
-            context: context)
-        let bottom = meanLuma(
-            image,
-            rect: CGRect(x: e.minX, y: e.minY, width: e.width, height: e.height / 2),
-            context: context)
-        return top > bottom + 0.08
+        let height = Int(e.height.rounded(.down))
+        guard height > 4, e.width > 2 else { return false }
+        var means: [Float] = []
+        means.reserveCapacity(height)
+        for row in 0..<height {
+            let y = e.minY + CGFloat(row)
+            means.append(
+                meanRGB(
+                    image,
+                    rect: CGRect(x: e.minX, y: y, width: e.width, height: 1),
+                    context: context))
+        }
+        var bestRow = 0
+        var bestMag: Float = 0
+        for i in 1..<height {
+            let mag = abs(means[i] - means[i - 1])
+            if mag > bestMag {
+                bestMag = mag
+                bestRow = i
+            }
+        }
+        guard bestMag > 0.04 else { return false }
+        return CGFloat(bestRow) > e.height / 2
     }
 
-    private static func meanLuma(_ image: CIImage, rect: CGRect, context: CIContext) -> Float {
+    /// CI top-center maps to Metal y = 0 (`FeedFrameBaker.metalOriginTransform`).
+    private static func metalTopIsBrighter(texture: MTLTexture, device: MTLDevice) -> Bool {
+        guard let queue = device.makeCommandQueue(),
+            let commandBuffer = queue.makeCommandBuffer(),
+            let blit = commandBuffer.makeBlitCommandEncoder()
+        else {
+            XCTFail("Metal blit readback unavailable")
+            return false
+        }
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: texture.pixelFormat,
+            width: texture.width,
+            height: texture.height,
+            mipmapped: false)
+        descriptor.storageMode = .shared
+        descriptor.usage = [.shaderRead, .shaderWrite]
+        guard let readable = device.makeTexture(descriptor: descriptor) else {
+            XCTFail("shared Metal texture unavailable")
+            return false
+        }
+        blit.copy(
+            from: texture,
+            sourceSlice: 0,
+            sourceLevel: 0,
+            sourceOrigin: MTLOrigin(x: 0, y: 0, z: 0),
+            sourceSize: MTLSize(width: texture.width, height: texture.height, depth: 1),
+            to: readable,
+            destinationSlice: 0,
+            destinationLevel: 0,
+            destinationOrigin: MTLOrigin(x: 0, y: 0, z: 0))
+        blit.endEncoding()
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+        if let error = commandBuffer.error {
+            XCTFail("Metal blit failed: \(error.localizedDescription)")
+            return false
+        }
+        let width = texture.width
+        let height = texture.height
+        let rowBytes = width * 4
+        var bytes = [UInt8](repeating: 0, count: rowBytes * height)
+        readable.getBytes(
+            &bytes, bytesPerRow: rowBytes,
+            from: MTLRegionMake2D(0, 0, width, height), mipmapLevel: 0)
+        func rowMean(_ rows: Range<Int>) -> Float {
+            var sum: Float = 0
+            var count = 0
+            for row in rows {
+                for x in 0..<width {
+                    let i = (row * width + x) * 4
+                    let b = Float(bytes[i])
+                    let g = Float(bytes[i + 1])
+                    let r = Float(bytes[i + 2])
+                    sum += (r + g + b) / 3
+                    count += 1
+                }
+            }
+            return sum / Float(max(count, 1)) / 255
+        }
+        return rowMean(0..<(height / 2)) > rowMean((height / 2)..<height) + 0.08
+    }
+
+    private static func meanRGB(_ image: CIImage, rect: CGRect, context: CIContext) -> Float {
         let w = max(1, Int(rect.width.rounded(.down)))
         let h = max(1, Int(rect.height.rounded(.down)))
         var bytes = [UInt8](repeating: 0, count: w * h * 4)
@@ -164,7 +243,7 @@ final class LiveFeedOrientationTests: XCTestCase {
             let r = Float(bytes[i * 4])
             let g = Float(bytes[i * 4 + 1])
             let b = Float(bytes[i * 4 + 2])
-            sum += 0.2126 * r + 0.7152 * g + 0.0722 * b
+            sum += (r + g + b) / 3
         }
         return sum / Float(max(pixels, 1)) / 255
     }

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -9,7 +9,7 @@ New and changed
 
 Fixes
 
-- This build has no new app behavior — keep testing Face Priority, shutter angle, and reconnect.
+- This build has no new app behavior — keep testing Face Priority, shutter angle, reconnect, and the live picture staying upright with false colour or LUT on.
 - Traffic Lights crush/clip compensation starts at 0 stops. Long-press LIGHTS if you want the old ¼-stop tolerance.
 - First connect no longer sits on Waiting for live-view when a few video packets arrive and then freeze.
 - While a subject is tracked, stick left/right matches the free gimbal instead of reversing.

--- a/scripts/ci-install-swift-android.sh
+++ b/scripts/ci-install-swift-android.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Install the official Swift 6.3.3 Android SDK on a GitHub-hosted Ubuntu runner.
+#
+# skiptools/swift-android-action cannot be used here: it references
+# actions/cache@v5 and reactivecircus/android-emulator-runner@v2, and repository
+# SHA pinning rejects those nested tags even when the emulator steps are skipped.
+set -euo pipefail
+
+readonly SWIFT_VERSION="6.3.3"
+readonly SDK_ID="swift-6.3.3-RELEASE_android"
+readonly SDK_URL="https://download.swift.org/swift-6.3.3-release/android-sdk/swift-6.3.3-RELEASE/swift-6.3.3-RELEASE_android.artifactbundle.tar.gz"
+readonly SDK_CHECKSUM="d160cc3206dd1886dae3fef2337af5e25ec034692cd0ec225721c56cc69da7f5"
+readonly TARGET="aarch64-unknown-linux-android29"
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+swift_bin="$(command -v swift || true)"
+[[ -n "$swift_bin" && -x "$swift_bin" ]] || fail "swift is not on PATH"
+swift_version="$("$swift_bin" --version)"
+[[ "$swift_version" == *"${SWIFT_VERSION}"* ]] || fail \
+  "Swift ${SWIFT_VERSION} is required; found: ${swift_version%%$'\n'*}"
+
+toolchain_bin="$(cd "$(dirname "$swift_bin")" && pwd -P)"
+[[ -x "$toolchain_bin/llvm-objcopy" ]] || fail "llvm-objcopy is missing beside $swift_bin"
+[[ -x "$toolchain_bin/llvm-objdump" ]] || fail "llvm-objdump is missing beside $swift_bin"
+
+if ! "$swift_bin" sdk list 2>/dev/null | grep -Fxq "$SDK_ID"; then
+  "$swift_bin" sdk install "$SDK_URL" --checksum "$SDK_CHECKSUM"
+fi
+
+"$swift_bin" sdk configure --show-configuration "$SDK_ID" "$TARGET" >/dev/null \
+  || fail "Swift Android SDK $SDK_ID is not configured for $TARGET"
+
+sdk_home=""
+candidates=(
+  "${HOME}/.swiftpm/swift-sdks/${SDK_ID}.artifactbundle/swift-android"
+  "${HOME}/.config/swiftpm/swift-sdks/${SDK_ID}.artifactbundle/swift-android"
+)
+if [[ -n "${XDG_CONFIG_HOME:-}" ]]; then
+  candidates+=("${XDG_CONFIG_HOME}/swiftpm/swift-sdks/${SDK_ID}.artifactbundle/swift-android")
+fi
+for candidate in "${candidates[@]}"; do
+  if [[ -x "${candidate}/scripts/setup-android-sdk.sh" ]]; then
+    sdk_home="$candidate"
+    break
+  fi
+done
+[[ -n "$sdk_home" ]] || fail "setup-android-sdk.sh is missing after installing $SDK_ID"
+
+: "${ANDROID_NDK_HOME:?ANDROID_NDK_HOME must point at NDK 27}"
+(cd "$sdk_home" && ./scripts/setup-android-sdk.sh)
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  {
+    echo "SWIFT_ANDROID_SDK_ID=${SDK_ID}"
+    echo "SWIFT_INSTALLATION=${toolchain_bin%/bin}"
+  } >> "$GITHUB_ENV"
+fi


### PR DESCRIPTION
## Why

PR #103 merged with failing **CI gate** checks (Detect changes, Native Swift/iOS, Android). Those jobs now run on the public repo and blocked the handbook PR because it touched `ci.yml`, `justfile`, and TestFlight notes.

## What failed

1. **Detect changes** on push to `docs/protocol-handbook`: `dorny/paths-filter` runs `git fetch origin main docs/protocol-handbook`. Git treats the slash as a refspec (`docs:protocol-handbook`).
2. **Android**: `skiptools/swift-android-action` references `actions/cache@v5` and `reactivecircus/android-emulator-runner@v2`. SHA pinning rejects those nested tags even when the emulator steps are skipped.
3. **Native Swift/iOS**: `LiveFeedOrientationTests` used luma as an orientation proxy. IRE false colour remaps paper white/black onto WAVE bands whose luma can invert while the raster stays upright. The baker test wrapped the Metal texture with `CIImage(mtlTexture:)`, whose origin has moved across Xcode versions.

## Fix

- Fetch `main` with an explicit refspec and `fetch-depth: 0` so the path-filter merge-base already exists.
- Install the official Swift 6.3.3 Android SDK with `scripts/ci-install-swift-android.sh` (Ubuntu 24.04 runners already ship Swift 6.3.3).
- Detect orientation from the white-band *edge* and from Metal row 0 (the present blit), not luma or `CIImage` wrap.

## Verification

- `just hygiene secrets lint-actions check-editorconfig typos lint-md testflight-notes`
- `swift-format lint` on the test file
- `LiveFeedOrientationTests` on the iPhone 16 Pro simulator (Xcode 26.2): 3/3 passed