### PR TITLE
ci: resolve the real Swift toolchain on Ubuntu runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ All notable changes to this project are documented here. The format is based on
   installs the official Swift Android SDK without nested unpinned actions; live
   feed orientation tests read spatial edges and Metal rows instead of luma
   after false colour.
+- Android CI follows the GitHub Ubuntu Swift toolchain symlink so
+  `llvm-objcopy` is found beside the real `swift` binary.
 - Public-launch GitHub settings: CI re-enabled with **CI gate** required on
   `main`, force-push off, Actions SHA pinning, and a `scripts/go-public.sh`
   walkthrough for the remaining visibility flip.

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -9,7 +9,7 @@ New and changed
 
 Fixes
 
-- This build has no new app behavior — keep testing Face Priority, shutter angle, reconnect, and the live picture staying upright with false colour or LUT on.
+- This build has no new app behavior — keep testing Face Priority, shutter angle, reconnect, and that the live picture stays upright with false colour or LUT on.
 - Traffic Lights crush/clip compensation starts at 0 stops. Long-press LIGHTS if you want the old ¼-stop tolerance.
 - First connect no longer sits on Waiting for live-view when a few video packets arrive and then freeze.
 - While a subject is tracked, stick left/right matches the free gimbal instead of reversing.

--- a/scripts/ci-install-swift-android.sh
+++ b/scripts/ci-install-swift-android.sh
@@ -19,20 +19,22 @@ fail() {
 
 swift_bin="$(command -v swift || true)"
 [[ -n "$swift_bin" && -x "$swift_bin" ]] || fail "swift is not on PATH"
+# GitHub Ubuntu images extract the toolchain to /usr/share/swift and only
+# symlink swift/swiftc into /usr/local/bin. llvm-objcopy and llvm-objdump stay
+# in the real usr/bin. Follow the binary; `pwd -P` on its directory is not enough.
+swift_bin="$(readlink -f "$swift_bin")"
+[[ -x "$swift_bin" ]] || fail "could not resolve the swift executable"
 swift_version="$("$swift_bin" --version)"
 [[ "$swift_version" == *"${SWIFT_VERSION}"* ]] || fail \
   "Swift ${SWIFT_VERSION} is required; found: ${swift_version%%$'\n'*}"
 
-toolchain_bin="$(cd "$(dirname "$swift_bin")" && pwd -P)"
+toolchain_bin="$(dirname "$swift_bin")"
 [[ -x "$toolchain_bin/llvm-objcopy" ]] || fail "llvm-objcopy is missing beside $swift_bin"
 [[ -x "$toolchain_bin/llvm-objdump" ]] || fail "llvm-objdump is missing beside $swift_bin"
 
 if ! "$swift_bin" sdk list 2>/dev/null | grep -Fxq "$SDK_ID"; then
   "$swift_bin" sdk install "$SDK_URL" --checksum "$SDK_CHECKSUM"
 fi
-
-"$swift_bin" sdk configure --show-configuration "$SDK_ID" "$TARGET" >/dev/null \
-  || fail "Swift Android SDK $SDK_ID is not configured for $TARGET"
 
 sdk_home=""
 candidates=(
@@ -51,11 +53,19 @@ done
 [[ -n "$sdk_home" ]] || fail "setup-android-sdk.sh is missing after installing $SDK_ID"
 
 : "${ANDROID_NDK_HOME:?ANDROID_NDK_HOME must point at NDK 27}"
+# GitHub-hosted Ubuntu sets ANDROID_NDK_ROOT. Swift 6.1+ Android SDKs treat that
+# as an NDK override and then fail to find Swift runtime libraries.
+# https://github.com/finagolfin/swift-android-sdk/issues/207
+unset ANDROID_NDK_ROOT
 (cd "$sdk_home" && ./scripts/setup-android-sdk.sh)
+
+"$swift_bin" sdk configure --show-configuration "$SDK_ID" "$TARGET" >/dev/null \
+  || fail "Swift Android SDK $SDK_ID is not configured for $TARGET"
 
 if [[ -n "${GITHUB_ENV:-}" ]]; then
   {
     echo "SWIFT_ANDROID_SDK_ID=${SDK_ID}"
     echo "SWIFT_INSTALLATION=${toolchain_bin%/bin}"
+    echo "ANDROID_NDK_ROOT="
   } >> "$GITHUB_ENV"
 fi


### PR DESCRIPTION
## Why

PR #105 merged with a failing **Android** job (and therefore **CI gate**). The install script treated `/usr/local/bin/swift` as the toolchain root.

GitHub Ubuntu images extract Swift 6.3.3 to `/usr/share/swift` and only symlink `swift`/`swiftc` into `/usr/local/bin`. `llvm-objcopy` lives next to the real binary, so:

```
error: llvm-objcopy is missing beside /usr/local/bin/swift
```

## Fix

- Follow the `swift` symlink with `readlink -f` before looking for LLVM tools, and export `SWIFT_INSTALLATION` from that real `usr/` directory.
- Run `setup-android-sdk.sh` before `swift sdk configure --show-configuration`.
- Clear `ANDROID_NDK_ROOT` on GitHub-hosted Ubuntu (Swift 6.1+ Android SDKs treat it as an NDK override).

## Verification

- Reproduced the PATH-symlink layout locally: `pwd -P` on `/usr/local/bin` misses `llvm-objcopy`; `readlink -f` finds it under `usr/share/swift/usr/bin`.
- `bash -n scripts/ci-install-swift-android.sh`
- `just check`