### PR TITLE
docs: thin AGENTS.md and split architecture from parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,63 +1,66 @@
 # OpenPocketCine
 
-Open-source iOS + Android app to connect to and monitor DJI Osmo Pocket cameras — primarily
-**Osmo Pocket 4 / 4 Pro**, with Nano live view on AVC. Built openly with agentic coding tools,
-held to clean engineering standards.
+Open-source iOS + Android app to connect to and monitor DJI Osmo Pocket cameras —
+primarily **Osmo Pocket 4 / 4 Pro**, with Nano live view on AVC.
 
-## Stack & tooling
+## Stack & paths
 
-- **Swift Package Manager / Swift** — production shared protocol core.
-- **SwiftUI** — production iOS app shell (`ios/OpenPocketCine`, generated with XcodeGen).
-- **Jetpack Compose / Kotlin** — production Android app shell.
-- **just** — the single entry point for repository tasks. Run `just` to list recipes.
-- **swift-format / swift test / xcodebuild** — formatting, tests, and iOS build checks.
-- **typos, editorconfig-checker, markdownlint-cli2, lychee, actionlint, gitleaks** — meta-checks.
+- **Swift Package Manager / Swift** — portable protocol core (`Sources/OpenPocketViewCore/`).
+- **SwiftUI** — iOS/iPadOS shell (`ios/OpenPocketCine/`, XcodeGen).
+- **Jetpack Compose / Kotlin** — Android shell (`Apps/Android/`).
+- **just** — every repo task. Run `just` to list recipes. `just setup` on macOS.
 
-Install local tooling with `just setup` (macOS / Homebrew).
+| Path | What |
+| --- | --- |
+| `Sources/OpenPocketViewCore/` | Portable Swift core |
+| `Tests/OpenPocketViewCoreTests/` | Core tests |
+| `ios/OpenPocketCine/` | SwiftUI shell |
+| `Apps/Android/` | Compose shell and adapters |
+| `Sources/OpenPocketCineAndroidFacade/` | Android JNI facade |
+| `docs/` | Engineering references |
+| `handbook/src/content/docs/` | Protocol handbook source |
+| `site/` | GitHub Pages landing |
+| `.github/` | CI and templates |
 
-## Where things live
-
-- `Sources/OpenPocketViewCore/` — production Swift shared core.
-- `Tests/OpenPocketViewCoreTests/` — Swift shared-core tests.
-- `ios/OpenPocketCine/` — production SwiftUI iOS app shell.
-- `Apps/Android/` — production Jetpack Compose app and platform adapters.
-- `captures/` — **gitignored.** Packet captures; never commit.
-- `docs/` — engineering references. Start with `commit-hygiene.md`.
-- `handbook/` — Astro Starlight protocol handbook (BLE, Wi-Fi, DUML). Preview with
-  `just handbook`. Markdown in `handbook/src/content/docs/` is the source. Shipped
-  at [openpocketcine.app/docs](https://openpocketcine.app/docs/) (GitHub Pages
-  merges it next to `site/`).
-- `site/` — GitHub Pages landing page.
-- `.github/` — CI workflows, issue/PR templates.
-
-## Supported agent tools
-
-OpenPocketCine supports **Claude Code** and **Codex** only. Shared instructions live here. Do not
-add Cursor, Copilot, Gemini, Windsurf, or other client-specific instruction files.
+`captures/` is gitignored.
 
 ## Hard rules
 
-- **Never commit `captures/`, `Osmo LUTS/`, `vendor/`, `ref/`, or `.local/`.** They contain
-  private or non-redistributable material.
-- **Never commit unofficial LUT dumps** (`Osmo LUTS/`). Official Rec.709 cubes in
-  `ios/OpenPocketCine/Resources/` are redistributable and tracked. See `docs/commit-hygiene.md`.
-- **Mind commit hygiene.** Never commit secrets, credentials, PII, or Wi-Fi passwords.
-- **Work on a branch and open a PR.** Do not commit directly to `main`.
-- **Conventional Commits** for every commit (`feat:`, `fix:`, `docs:`, `chore:`, `ci:`, `build:`,
-  `test:`).
-- **Keep the Swift core portable.** No SwiftUI, UIKit, Android, Compose, or filesystem/UI
-  dependencies in protocol/business logic.
+- Keep the Swift core **portable**: Foundation-only protocol and business logic.
+- Live view is **enable-once**: `0x09/0xa8` starts the stream and is the only PLI. After picture, further enables follow the **watchdog** only.
+- **Hygiene:** secrets, camera Wi-Fi passwords, PII, unofficial LUT dumps, and `captures/`, `Osmo LUTS/`, `vendor/`, `ref/`, `.local/` stay out of git. Official Rec.709 cubes under `ios/OpenPocketCine/Resources/` and `Apps/Android/app/src/main/assets/luts/` are tracked.
+- Work on a branch and open a PR. Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, `ci:`, `build:`, `test:`).
+- `AGENTS.md` is canonical for every agent. Client stubs (`CLAUDE.md`, `CODEX.md`, `GROK.md`) are pointers only — do not copy these rules into a second instruction file. Do not add Cursor, Copilot, Gemini, or Windsurf instruction dumps.
+
+## Before you edit
+
+1. Name the surface: core, iOS **shell**, Android **shell**, or docs.
+2. Load every pointer whose trigger matches.
+3. If the change is operator-visible, read **parity** and touch both shells or record the exception in `docs/PARITY.md`.
+
+## Read when
+
+- **naming** — fuzzy term, new name, operator-visible copy: [`CONTEXT.md`](CONTEXT.md)
+- **seams** — new module, core vs shell, spine order: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
+- **parity** — chrome, assist, connection UX, one-platform feature: [`docs/PARITY.md`](docs/PARITY.md)
+- **JNI** — Gradle, Swift-for-Android, `.so`, facade, OpenZCine pattern: [`ANDROID.md`](ANDROID.md)
+- **live-session** — freeze, black feed, reconnect, UDP bind, ACK, decoder: [`docs/live-session.md`](docs/live-session.md)
+- **watchdog** — stall, GOP-reset grace, recover `0x09/0xa8`: [`docs/feed-watchdog.md`](docs/feed-watchdog.md)
+- **protocol** — DUML, BLE, opcode, pktType, HEVC/AVC payload: `handbook/src/content/docs/`
+- **hygiene** — commit/PR that might touch secrets, LUTs, captures, identity: [`docs/commit-hygiene.md`](docs/commit-hygiene.md)
+- **contributing** — issues vs discussions, labels, human setup: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
 ## Verification
 
-- `just check` — full repository quality gate (hygiene, site, typos, markdown, links,
-  editorconfig, actionlint, secrets, swift-format lint, swift test).
+- `just check` — full repository quality gate.
 - `just native-check` — Swift lint/test plus iOS simulator build and tests.
 - `just android-check` — Gradle assembleDebug, unit tests, lint.
-- UI / chrome changes: build-run on a physical iPhone or connected Android device. Compile-only
-  is not done for operator-visible work. Simulator cannot exercise BLE or camera Wi-Fi.
+- **physical:** operator-visible work is proven on a real iPhone or Android device for the platform changed. Simulator has no BLE or camera Wi-Fi. Compile-only is not done.
 
 ## Completion
 
-A task is not done until `just check` is green for the paths you touched, docs that describe the
-behavior are updated, and no forbidden paths are staged.
+A task is not done until `just check` is green for the paths touched, docs that describe the behavior are updated, **parity** is held or an exception is recorded in `docs/PARITY.md`, no forbidden paths are staged, and operator-visible work is **physical** for the platform changed.
+
+## Sediment
+
+`STATUS.md`, `OVERNIGHT.md`, and `.planning/` are local or dated notes. They are not current architecture. `docs/connection-reliability-plan.md` is a dated PR plan, not a contract.

--- a/ANDROID.md
+++ b/ANDROID.md
@@ -8,6 +8,10 @@ Business logic stays in **`OpenPocketViewCore`** (UI-free, I/O-free Foundation).
 Android follows the public [OpenZCine](https://github.com/erik-sutton95/OpenZCine)
 pattern rather than Skip/SKIE/an xcframework.
 
+Operator-visible behavior lives in [`docs/PARITY.md`](docs/PARITY.md). Live UDP
+and decoder invariants live in [`docs/live-session.md`](docs/live-session.md).
+This file is the Android build and I/O notes that implement those rows.
+
 ## How the Android build is structured
 
 Source: the public [OpenZCine](https://github.com/erik-sutton95/OpenZCine) repository.
@@ -44,29 +48,52 @@ Done in-tree (see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)):
 3. Gradle `:app:stageSwiftCore` stages `libOpenPocketCineAndroid.so`.
 4. Compose splash → empty-store wizard / saved list → live HEVC (MediaCodec) using enable-once + ACK pump.
 
-## Operator parity (iOS baseline)
+## Android I/O notes
 
-The Compose shell now tracks the iOS operator surface, with Apple-only pieces skipped:
+How this shell implements [`docs/PARITY.md`](docs/PARITY.md). Contract language stays there.
 
-- **Connection:** BLE → SoftAP → UDP datalink, FeedWatchdog-style enable policy (never 1 Hz `0x09/0xa8`). Bind UDP `0.0.0.0:0` (ephemeral local port, like iOS/Mimo) then connect `192.168.2.1:9004` — a local `:9004` bind accepted handshake + `0x01` and dropped HEVC. Arm HEVC ingest on the enable write like iOS/Mimo — do not wait for a DUML ACK (that 200 ms window dropped the VPS). Do not send gallery `0x02/0x0c` to start live view — only when status says playback. First-picture recover stays armed after a SoftAP flap (`holdsMonitor` must not latch a forever skip). Session recovery holds the last frame. Disconnect disposes the UDP driver (callbacks, executors, sockets) and joins the MediaCodec output thread so a reconnect does not inherit a half-dead live session — force-stopping the app was the only reliable reset. Stale `open()` after cancel is ignored. Nano AVC + Pocket HEVC via MediaCodec 720p at the body's live rate (wall-clock PTS, `KEY_LOW_LATENCY`; do not pace at 30 fps). Cached Wi-Fi creds in private prefs (not saved-camera JSON).
-- **Live chrome:** landscape/portrait layout metrics matching iOS (`LiveDesign`). Portrait Fill center-crops the 16:9 picture into the taller well (iOS `fillCrop`) — it does not stretch. Pocket screen flip (taller HEVC SPS) rebuilds MediaCodec and pillarboxes 9:16 in the cinema 16:9 well (`LiveMonitorLayout.pictureFrame`, iOS `pictureAspect`) — zoom/gimbal stay on the well. DISP 1/2 maps, chrome editor, record confirmation as a bottom action sheet (not a centred dialog), zoom chip, gimbal stick with the iOS 1–5 sensitivity gain (`GimbalStick.encode` / `SwiftCore.gimbalStickEncode`), rec lamp calling `pressShutter` (photo / SuperNight still; video start/stop otherwise). Capture, format/color, and assist long-press popups use `liveChromeGlass` (same ND plate as the HUD) plus the circular glass close — not an opaque black card with a text ✕. Every View Assist options sheet and capture picker (ISO / shutter / WB drums) uses the LUT chrome: 27 dp close, 12 dp pad / 8 dp gap, 0.12/0.88 drum fade with 27/20 pt faces, and a well from a 12 dp top margin down to the bar (short menus hug; ISO / shutter / WB drums fill so neighbours peek). FORMAT and COLOR hang 8 dp under the top-deck chips at 340 dp (iOS `LiveTopPickerHost`) and hug — they do not fill to the assist bar. Storage toggles GB·% vs remaining minutes. LUT drum faces 27/20 pt with 0.12/0.88 fade so neighbours peek, and 50/50 stays pinned. Picker / assist cards add a 0.20 black ND on HUD glass so they read a tad denser than the bars, and sample the scene backdrop so liquid glass blurs chrome under the sheet. Capture sheets reseat ISO/shutter drums only on the iOS `onChange` keys (available ISO list, color mode, shutter list, fps, expo mode) so opening Manual or scrolling a wheel does not snap back to the first option.
-- **Assists:** toolbar 1:1 (LUT, PEAK, FALSE, ZEBRA, WAVE, PARADE, HISTO, VECTOR, LIGHTS, AUDIO, GUIDES, GRID, CROSS, MIRROR). Long-press options use the same settings rows, capsule switches, percent sliders, and number fields as iOS `AssistLongPressChrome`. WAVE hold-without-drag opens options (iOS `WaveformAssist.shouldPresentOptions`). Scope panels copy iOS `ScopeMiniChrome` (0.72 rounded plate, hairline, 16 dp corner, 16 dp shadow) and `WaveformMovablePanel` (0.3 s hold then drag, L-corner 2 dp outside the clip, scale 0.6…1.6). WAVE / PARADE / VECTOR / HISTO paint the plate and traces in one Compose Canvas (iOS `plusLighter` on a `compositingGroup`) — no plot hole, no Kyant on the plates, no lagged Vulkan overlay. WAVE / PARADE density-accumulate into a 250×153 bitmap off the UI thread; VECTOR uses the 128-bin raster; Compose blits. Vulkan grades the picture and downsamples a 213×120 tap on the 10–15 Hz sample tick (not every HEVC frame). Last touched or moved panel stacks on top. Scopes sit above the feed and the focus / tracking box, under the top deck, View Assist bar, and camera-value strip. Feed PixelCopy for HUD Kyant is ~20 Hz. The pinch well is the feed rectangle *under* the panels so a hold on HISTO is not stolen by pinch. Histogram gutters are 17.5 dp (traffic lamps + 0 / 100), not 17.5 px. Zebra 0–255 shows encoded codes via `ScopeDisplayScale.signalNative`; stored thresholds stay 0–100 IRE. PStops reference ruler paints EV-domain bands + Min/−3/18%/Skin/+2/Max markers, not IRE labels. Canvas paints guides/grid/crosshair and scope chrome. Live picture runs on Vulkan (`libopc_vulkan.so`): MediaCodec writes an `ImageReader` AHB. Assists off: one YCbCr blit of the MediaCodec AHB into the well (hardware `c2.qti` / Exynos HEVC, not `c2.android`). LUT / FALSE / ZEBRA add the grade pass; WAVE / HISTO tap at 10–15 Hz. Tools-off no longer histograms 1280×720 or readbacks every frame. Rounded 0.72 plates are Compose `ScopeMiniChrome`. Live HUD liquid glass is Kyant [`AndroidLiquidGlass`](https://github.com/Kyant0/AndroidLiquidGlass) (`io.github.kyant0:backdrop`) when the hardware gate allows it (API 33+ and ≥4 GB RAM, not `isLowRamDevice`). There is no frame-budget demote — FULL stays FULL. Kyant cannot sample a SurfaceView, so FULL glass PixelCopies the feed well into the recorded Compose layer. Older / low-RAM devices stay on solid frost. GLES `FeedEffectsGlProgram` remains the decode fallback when Vulkan cannot init.
-- **Operator Setup:** seven tabs (Link, Sharing, View Assist, Controls, Display, Storage, System), DJI Black, Sora + IBM Plex, NOTICE legal page. Frame.io is **Not configured** (optional on iOS too).
-- **Media:** camera catalog + SoftAP HTTP cache + ExoPlayer/photo viewer + system share. Share / Save to Photos caches the original camera file (`MediaHTTP.deliveryPath`). Playback opens the 720p LRF/XRF sidecar even when the 4K original is already cached. Playback chrome is an 82% DJI-black plate (no Kyant); the top row is back + filename + star, not a bar. LUT / PEAK / FALSE / ZEBRA grade the proxy in GLES (ExoPlayer writes an OES surface; TextureView is only the window). WAVE / HISTO tap that GL copy. Overlay assists sit above the player. Live HEVC is held while the library covers the monitor. Playback View Assist rail is independent of live. No Frame.io hop.
+### Connection
 
-- **Camera SETs:** same mailbox as iOS `fireCamera` / `CameraSetMailbox`. ISO, shutter, WB, focus, FORMAT, COLOR, EV, record, tracking fire-and-forget with 300 ms retransmit and a 2 s settle — a missed ACK is not `"Color timed out"` and does not revert the HUD. Native ISO hops D-Log 400 ↔ D-Log2 1600 immediately after the color SET (toggle on the ISO sheet). Audio blobs and tap-focus stay true round-trips (`requestCamera`, 800 ms tap burst) and keep timeouts off the HUD.
-- **Zoom:** chip cycles 1× → 3× → 6× → 12× → 1× on slider `0x02/0xB8` `0A 4E` + lens 217 / 651 / 1302 / 2604. The chip number is `CamFov` hybrid (lens `@14`, else inverted `cam_fov` `@0`) — never `@0 / 1024` (12287 is 1×, not 12×). Pinch writes every distinct lens tick at 20 Hz without waiting for ACK (transparent hit well over the Vulkan SurfaceView, iOS `LiveZoomPinchWell`); D-Log2 hops to D-Log on the first step off 1× and restores only when parked back at 1×.
-- **Tracking:** long-press then drag on the feed draws a search box and SETs `0x02/0xA6` (centre+size). AF-C face brackets come from a 40 ms RGB tap of the live picture (`android.media.FaceDetector`, iOS Vision). Tap a bracket to start ActiveTrack. The camera pushes the locked subject on `0x02/0x89`; we poll `0xA5` until idle. Green cancel X and focus-reset match iOS.
+`bindProcessToNetwork` then UDP `0.0.0.0:0` after `Network.bindSocket`. MediaCodec
+uses wall-clock PTS and `KEY_LOW_LATENCY`; do not pace at 30 fps. Cached Wi-Fi
+creds sit in private prefs, not saved-camera JSON. `holdsMonitor` must not latch
+a forever skip after a SoftAP flap.
 
-Skip / later: VideoToolbox, MetalFX super-res, iOS 26 Liquid Glass API, Frame.io OAuth, LEVEL/De-SQ/MAG.
+### Live picture
 
-OpenZCine Android patterns adopted (not Nikon PTP/USB/Wear/OCR):
+Vulkan (`libopc_vulkan.so`) when init succeeds: MediaCodec → `ImageReader`
+AHardwareBuffer → YCbCr blit at the feed well. GLES `FeedEffectsGlProgram` on
+`GL_TEXTURE_EXTERNAL_OES` is the fallback.
+
+### HUD glass
+
+Kyant `AndroidLiquidGlass` on API 33+ / ≥4 GB devices that are not
+`isLowRamDevice`. FULL stays FULL (no frame-budget demote). Kyant cannot sample
+a SurfaceView, so FULL glass PixelCopies the feed well at ~20 Hz. Pairing,
+Operator Setup, and media list rows stay solid fills.
+
+### Assists GPU
+
+Assists-off is one YCbCr blit of the MediaCodec AHB (hardware `c2.qti` / Exynos
+HEVC, not `c2.android`). LUT / FALSE / ZEBRA add the grade pass. WAVE / PARADE /
+VECTOR / HISTO tap a 213×120 downsample at 10–15 Hz and paint in Compose Canvas.
+WAVE / PARADE accumulate into a 250×153 bitmap off the UI thread; VECTOR uses
+the 128-bin raster.
+
+### Media decode
+
+Playback grades the 720p LRF/XRF proxy in GLES (ExoPlayer → OES → TextureView).
+Share / Save to Photos caches the original (`MediaHTTP.deliveryPath`).
+
+## OpenZCine Android patterns adopted
+
+Not Nikon PTP/USB/Wear/OCR:
 
 - Keystore AES/GCM Wi-Fi password store (`CameraWifiCredentialStore`)
 - `WIFI_MODE_FULL_LOW_LATENCY` lock while live
 - In-app-gated operator haptics
 - AAR `compileSdk` 37 metadata gate disabled so the project stays on SDK 36
 - Shared `CubeLUT` packer (`LUTLibraryWire`) for GLES-ready RGBA cubes
-- GLES ES2 feed-effect shaders under `assets/shaders/`. MediaCodec writes an OES `SurfaceTexture`; `LiveFeedEffectsSession` blits to 2D and runs `FeedEffectsGlProgram` into the TextureView (Kyant can still sample the picture).
+- GLES ES2 feed-effect shaders under `assets/shaders/`
 - Media cache complete-at-exact-length + `noBackupFilesDir`
 - Sticky `ACTION_BATTERY_CHANGED` readout instead of a 1 Hz poll

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ All notable changes to this project are documented here. The format is based on
 
 ### Changed
 
+- Agent instructions are a thin [`AGENTS.md`](AGENTS.md) index. Operator-visible
+  contract lives in [`docs/PARITY.md`](docs/PARITY.md); live UDP and decoder
+  facts in [`docs/live-session.md`](docs/live-session.md); glossary in
+  [`CONTEXT.md`](CONTEXT.md). [`ANDROID.md`](ANDROID.md) is build/JNI/I/O only.
+
 - Android live scopes match iOS `ScopeMiniChrome` / `WaveformMovablePanel`:
   DJI-black 72% plates (`LiveDesign.scopePlate`). WAVE / PARADE / VECTOR /
   HISTO paint fill and traces in one Compose Canvas (iOS `plusLighter` on

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,4 +1,4 @@
-# OpenPocketCine Claude Code guide
+# OpenPocketCine Codex guide
 
 Canonical project guidance is [`AGENTS.md`](AGENTS.md). Do not copy it here.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,62 @@
+# OpenPocketCine
+
+Shared language for the Osmo field-monitor domain. Implementation lives in the
+code and in `docs/`; this file is the glossary only.
+
+## Language
+
+**Core**:
+The portable Swift protocol and business-logic package (`OpenPocketViewCore`).
+_Avoid_: SDK, engine, shared module
+
+**Shell**:
+The platform app that owns I/O and UI: SwiftUI on iOS, Compose on Android.
+_Avoid_: client, frontend, app layer
+
+**Facade**:
+The Android JNI session boundary (`OpenPocketCineAndroidFacade`).
+_Avoid_: bridge, wrapper
+
+**Spine**:
+Required connection order: BLE → SoftAP → UDP datalink → live view.
+_Avoid_: pipeline, stack
+
+**SoftAP**:
+The camera’s Wi-Fi access point at `192.168.2.1`.
+_Avoid_: hotspot (except when naming the iOS API)
+
+**Datalink**:
+UDP port 9004 DUML transport between phone and camera.
+_Avoid_: media port, stream
+
+**Enable-once**:
+`0x09/0xa8` starts live view and is the only PLI; it is not a 1 Hz keyframe loop.
+_Avoid_: IDR loop, live-start (alone)
+
+**Watchdog**:
+Portable stall-and-recover policy (`FeedWatchdog`).
+_Avoid_: keepalive, heartbeat
+
+**Chrome**:
+Operator HUD around the picture (bars, chips, DISP), not the picture.
+_Avoid_: UI, overlay
+
+**Parity**:
+Operator-visible match to the iOS baseline unless `docs/PARITY.md` lists an exception.
+_Avoid_: pixel-identical, 1:1 clone
+
+**Assist**:
+A monitor tool on the picture (LUT, peaking, zebra, scopes, grids).
+_Avoid_: filter, effect
+
+**Physical**:
+Proof on a real phone. Simulator cannot exercise BLE or camera Wi-Fi.
+_Avoid_: on-device (prefer **physical**)
+
+**Hygiene**:
+Secrets, captures, unofficial LUTs, and PII stay out of git.
+_Avoid_: cleanliness
+
+**Portable**:
+Foundation-only core: no SwiftUI, UIKit, Android, Compose, or filesystem I/O.
+_Avoid_: cross-platform, shared

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,7 @@ Frame.io upload is **disabled unless you configure it**. Copy
 
 ## Code standards
 
+- Agent instructions live in [`AGENTS.md`](AGENTS.md). Do not copy them here.
 - The production target is a shared Swift business/protocol core with native UI shells: SwiftUI on
   iOS and Jetpack Compose on Android.
 - Composition over inheritance; prefer small pure functions and immutable data.

--- a/GROK.md
+++ b/GROK.md
@@ -1,4 +1,4 @@
-# OpenPocketCine Claude Code guide
+# OpenPocketCine Grok guide
 
 Canonical project guidance is [`AGENTS.md`](AGENTS.md). Do not copy it here.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,9 +4,9 @@ OpenPocketCine is a shared Swift business/protocol core with native platform she
 
 | Layer | Path | Purpose |
 | --- | --- | --- |
-| **Shared core** | `Sources/OpenPocketViewCore/` | DUML framing, datalink, BLE advert decode, commands, status, LUTs, layout policy. Pure Foundation — no SwiftUI, UIKit, Android, or I/O. |
-| **iOS app** | `ios/OpenPocketCine/` | SwiftUI shell, CoreBluetooth, NEHotspotConfiguration, sockets, VideoToolbox/Metal. Disconnect bumps UDP generation, drops driver callbacks, invalidates VT, and ignores a cancelled `open()` that still wants to publish LIVE — in-app reconnect must not inherit a half-closed live session. |
-| **Android app** | `Apps/Android/app/` | Jetpack Compose phone shell. Live picture presents through Vulkan (`Apps/Android/app/src/main/cpp`, `libopc_vulkan.so`) when the device can init it: MediaCodec → `ImageReader` AHardwareBuffer → YCbCr sample at the feed well + LUT atlas. Compose paints WAVE / PARADE / VECTOR / HISTO on the 0.72 plate (a 213×120 tap at 10–15 Hz, compute histogram). Live HUD liquid glass is Kyant AndroidLiquidGlass on API 33+ / ≥4 GB devices (no runtime quality demote). Disconnect tears down the UDP driver and MediaCodec output thread so reconnect does not reuse a half-closed live session. Pairing, Operator Setup, and media list rows stay solid fills. Playback chrome is an 82% DJI-black plate (no Kyant). Playback uses the 720p LRF/XRF proxy; export caches the 4K original. LUT / PEAK / FALSE / ZEBRA grade that proxy in GLES (ExoPlayer → OES → TextureView); WAVE taps the GL copy. GLES `FeedEffectsGlProgram` on `GL_TEXTURE_EXTERNAL_OES` is the fallback when Vulkan cannot init. Live HUD chrome scales with shortest-side dp (`monitorChromeScale`, 0.935–1.0 vs a 424 dp Pro Max / 6.8" board). Landscape feed leading is floored at the iPhone island lane (`monitorLeadingInsetDp`); compact 16:9 phones slide the well left only enough for the record rail to clear the picture. Portrait Fill center-crops 16:9 into the fill well (iOS `fillCrop`). System bars are sticky-immersive (`ImmersiveSystemBars.kt`). |
+| **Shared core** | `Sources/OpenPocketViewCore/` | DUML, commands, status, LUTs, layout policy. **Portable** Foundation. |
+| **iOS app** | `ios/OpenPocketCine/` | SwiftUI **shell**, CoreBluetooth, NEHotspotConfiguration, sockets, VideoToolbox/Metal. Teardown: [live-session](live-session.md). |
+| **Android app** | `Apps/Android/app/` | Compose **shell**. Live picture and HUD I/O: [`ANDROID.md`](../ANDROID.md). Operator-visible behavior: [parity](PARITY.md). Teardown: [live-session](live-session.md). |
 | **Android facade** | `Sources/OpenPocketCineAndroidFacade/` | Swift session and JNI boundary |
 | **Tests** | `Tests/OpenPocketViewCoreTests/` | Swift Testing suite for the portable core |
 
@@ -21,34 +21,14 @@ The iOS Xcode project is generated: `cd ios && xcodegen generate`.
 
 1. BLE scan and pair (GATT FFF0).
 2. Read camera Wi-Fi credentials.
-3. Join the camera SoftAP (`192.168.2.1`). The phone is on-path only after DHCP
-   gives it `192.168.2.2…254` (`CameraSoftAP.isAssociatedIPv4`).
-4. UDP DUML datalink on that LAN, connected to `192.168.2.1:9004`. iOS binds
-   the DHCP IPv4 + an **ephemeral local port** (`NWParameters.requiredLocalEndpoint`
-   port 0). Android pins the process with `bindProcessToNetwork` and binds UDP
-   `0.0.0.0:0` after `Network.bindSocket`. Camera 9004 is the remote only —
-   binding local `:9004` on Samsung accepted handshake + `0x01` telemetry and
-   dropped every pktType `0x02` (`videoPkts=0`, WAITING FOR LIVE VIEW). Mimo
-   live-entry uses an ephemeral client port. Keep TCP 7001 poke across UDP
-   rebuilds.
-5. Enable live view once after path + display are ready. Pocket sends
-   `0x02/0x68` payload `08` immediately before `0x09/0xa8` (Mimo first live
-   after gallery). Arm pktType `0x02` ingest on that write — do not wait for
-   a DUML ACK (VPS is 25–167 ms; a 200 ms wait dropped it). Never 1 Hz.
-   Media is pktType `0x02`; window ACK is pktType `0x04` at 40 Hz echoing the
-   video seq. Disconnect has no live-stop — leftover GOP P-frames during
-   handshake are expected until this pair starts a clean VPS. In-app
-   Disconnect must still drop the UDP driver (`udpGeneration` / closed flag,
-   callbacks, ACK pump) and the platform decoder (VT invalidate + layer flush
-   on iOS; MediaCodec output-thread join + Surface unbind on Android). A
-   cancelled `open()` must not publish LIVE (`CameraSoftAP.shouldCommitLiveHandshake`).
-   Process death did that for free; leaving the socket live is why reconnect
-   hung on Waiting for live view until the app was killed.
-6. Pocket 4 / 4 Pro: HEVC 720p. Nano: AVC/H.264 High 720p. Configure the
-   decoder from VPS/SPS/PPS (`0x40/0x42/0x44`) or Nano AVC SPS/PPS (`0x67/0x68`).
-   Leftover TRAIL P-frames and HEVC IDR_N_LP (`0x28`, also AVC PPS with
-   `nal_ref_idc=1`) must not latch AVC — that threw `MediaCodec.configure` and
-   left Waiting for live view up.
+3. Join SoftAP `192.168.2.1`. On-path only after DHCP `192.168.2.2…254`
+   (`CameraSoftAP.isAssociatedIPv4`).
+4. UDP DUML to `192.168.2.1:9004` on an **ephemeral local port**. Camera 9004 is
+   the remote only. Bind and ACK details: [live-session](live-session.md).
+5. Enable live view **enable-once** after path + display are ready. Arm pktType
+   `0x02` ingest on that write. Recover policy: [watchdog](feed-watchdog.md).
+6. Pocket 4 / 4 Pro: HEVC 720p. Nano: AVC/H.264 High 720p. Decoder setup and
+   NAL latch: [live-session](live-session.md).
 
 ### Policy in Swift, I/O in the shells
 
@@ -61,19 +41,13 @@ SDK). Both apps must call the same state machines:
 | Stall, GOP-reset grace, AF-C grace, enable-once, rebuild ladder | `FeedWatchdog` | iOS `CameraSession.applyFeedWatchdog`; Android JNI `feedWatchdogCreate/Tick` — not a second Kotlin clone |
 | Drop storm, bounded reconnect | `SessionRecovery` | platform BLE rescan + SoftAP rejoin |
 | Link score → 0–4 bars | `CameraLinkHealth` + `LinkSignalBars` | top-bar FPS chip (delivery health, not RSSI) |
+| Camera SET mailbox, retransmit, settle | `CameraSetMailbox` | iOS `fireCamera`; Android JNI |
 
 Platform shells own sockets, BLE, SoftAP join, permissions, lifecycle, rendering,
 storage, and UI. Do not import SwiftUI, UIKit, Android, or Compose into the core.
 
-iOS is the operator-proven datalink (`DatalinkDriver.swift` `requiredLocalEndpoint` =
-camera DHCP IPv4; `noteSceneBecameActive` → `recoverAfterForeground`). Android must
-match that 5-tuple and lifecycle, not reimplement the ladder in
-`LiveViewEnablePolicy`. Mid-session SoftAP `onLost` is a Network-object replace until
-the grace expires — do not `bindProcessToNetwork(null)` while `isProcessBound` still
-reads true, or UDP rebuilds on home Wi-Fi.
-
-See [`feed-watchdog.md`](feed-watchdog.md) and
-[`connection-reliability-plan.md`](connection-reliability-plan.md).
+See [`live-session.md`](live-session.md), [`feed-watchdog.md`](feed-watchdog.md),
+[`PARITY.md`](PARITY.md), and [`ANDROID.md`](../ANDROID.md).
 
 See the [protocol handbook](https://openpocketcine.app/docs/) for wire-level detail
 (Markdown source in `handbook/src/content/docs/`; stub at [`protocol-notes.md`](protocol-notes.md)).

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -1,0 +1,45 @@
+# Operator parity
+
+iOS is the operator-proven baseline. Android matches operator-visible behavior
+unless a row lists an exception. GPU backends, Bluetooth stacks, and OS APIs may
+diverge. Shipping a one-platform operator-visible change without a row here is
+incomplete.
+
+Before changing an operator-visible surface, read this file. Ship both shells or
+write the exception in the table in the same PR.
+
+| Surface | Must match | May diverge | Verify |
+| --- | --- | --- | --- |
+| Connection FTUE and spine | BLE → SoftAP → UDP; **enable-once**; ephemeral local port; arm `0x02` on enable write; disconnect drops driver + decoder; session recovery holds last frame | iOS `NEHotspotConfiguration` vs Android `WifiNetworkSpecifier` + `bindProcessToNetwork`; Network.framework vs Android sockets | **physical** both |
+| Live chrome | DISP 1/2 maps, layout metrics (`LiveDesign` / `fillCrop` / screen-flip pillarbox), picker chrome, record as bottom sheet, zoom chip, gimbal 1–5 gain, rec lamp `pressShutter` | iOS Liquid Glass vs Kyant (API 33+ and ≥4 GB; else solid frost); SF Symbols / Material only where Lucide catalog has not replaced them | **physical** both |
+| Assists | Toolbar 1:1 (LUT, PEAK, FALSE, ZEBRA, WAVE, PARADE, HISTO, VECTOR, LIGHTS, AUDIO, GUIDES, GRID, CROSS, MIRROR); long-press options; WAVE hold-without-drag opens options; scope plate metrics (`ScopeMiniChrome`) | Metal vs Vulkan vs GLES; Vision vs `android.media.FaceDetector`; PixelCopy / Kyant sampling | **physical** both |
+| Camera SETs | `CameraSetMailbox` fire-and-forget + 300 ms retransmit + 2 s settle; missed ACK does not revert HUD; ISO D-Log ↔ D-Log2 hop; audio blobs and tap-focus stay round-trips | JNI vs Swift `fireCamera` | **physical** both |
+| Zoom | Chip 1×→3×→6×→12×; `CamFov` hybrid readout; pinch at 20 Hz without ACK wait; D-Log2 hops to D-Log off 1× | Hit-testing over SurfaceView vs SwiftUI | **physical** both |
+| Tracking | Long-press+drag search box `0x02/0xA6`; tap face bracket → ActiveTrack; green cancel X and focus-reset | Face detector implementation | **physical** both |
+| Operator Setup | Seven tabs (Link, Sharing, View Assist, Controls, Display, Storage, System); DJI Black; Sora + IBM Plex; NOTICE legal | Frame.io row is “Not configured” until iOS keys exist | **physical** both |
+| Media | Camera catalog, SoftAP HTTP cache, 720p LRF/XRF proxy playback, independent playback assist rail, live HEVC held while library covers the monitor | Frame.io C2C and LUT bake on export: iOS only. Android share/save uses the original (`MediaHTTP.deliveryPath`). Playback chrome is an 82% DJI-black plate (no Kyant). | **physical** both |
+| Explicit skip | — | VideoToolbox, MetalFX super-res, iOS 26 Liquid Glass API, Frame.io OAuth, LEVEL / De-SQ / MAG | n/a |
+
+Datalink bind, ACK, enable-write, and decoder latch facts live in
+[`live-session.md`](live-session.md). Android I/O that implements these rows
+lives in [`ANDROID.md`](../ANDROID.md).
+
+## Chrome metrics
+
+Must match across shells. Do not keep a second copy in `ANDROID.md`.
+
+- View Assist options and capture pickers: 27 dp close, 12 dp pad, 8 dp gap.
+- Drum faces 27/20 pt with 0.12/0.88 fade. ISO / shutter / WB drums fill so
+  neighbours peek; short menus hug.
+- FORMAT and COLOR hang 8 dp under the top-deck chips at 340 dp
+  (`LiveTopPickerHost`) and hug — they do not fill to the assist bar.
+- LUT 50/50 stays pinned.
+- Picker / assist cards add a 0.20 black ND on HUD glass.
+- `ScopeMiniChrome`: 0.72 rounded plate, hairline, 16 dp corner, 16 dp shadow.
+- Movable scope panel: 0.3 s hold then drag, L-corner 2 dp outside the clip,
+  scale 0.6…1.6.
+- Histogram gutters 17.5 dp (traffic lamps + 0 / 100), not 17.5 px.
+- Zebra stored thresholds stay 0–100 IRE; 0–255 readout is encoded codes via
+  `ScopeDisplayScale.signalNative`.
+- PStops reference ruler paints EV-domain bands + Min/−3/18%/Skin/+2/Max
+  markers, not IRE labels.

--- a/docs/live-session.md
+++ b/docs/live-session.md
@@ -1,0 +1,69 @@
+# Live session
+
+Current I/O facts for the live UDP session and platform decoders. Not a diary.
+Stall and recover policy lives in [`feed-watchdog.md`](feed-watchdog.md).
+
+## 5-tuple
+
+One UDP flow: camera `192.168.2.1:9004` is the **remote** only.
+
+- iOS binds the camera DHCP IPv4 plus an **ephemeral local port**
+  (`NWParameters.requiredLocalEndpoint` port 0).
+- Android pins the process with `bindProcessToNetwork` and binds UDP `0.0.0.0:0`
+  after `Network.bindSocket`.
+
+Binding local `:9004` on Samsung accepted handshake + `0x01` telemetry and
+dropped every pktType `0x02` (`videoPkts=0`, WAITING FOR LIVE VIEW). Mimo
+live-entry uses an ephemeral client port.
+
+## ACK pump
+
+Window ACK is pktType `0x04` at 40 Hz, cursor = latest video transport seq.
+Keep TCP 7001 poke across UDP rebuilds.
+
+## Enable write
+
+Arm pktType `0x02` ingest on the enable write — do not wait for a DUML ACK
+(VPS is 25–167 ms; a 200 ms wait dropped it). Pocket may send `0x02/0x68`
+payload `08` immediately before `0x09/0xa8` (Mimo first live after gallery).
+
+**Enable-once:** `0x09/0xa8` starts the stream and is the only PLI. After
+picture, further enables follow the [watchdog](feed-watchdog.md) only.
+
+Media is pktType `0x02`. Disconnect has no live-stop — leftover GOP P-frames
+during handshake are expected until this pair starts a clean VPS.
+
+## Disconnect teardown
+
+In-app Disconnect must drop the UDP driver (`udpGeneration` / closed flag,
+callbacks, ACK pump) and the platform decoder (VT invalidate + layer flush
+on iOS; MediaCodec output-thread join + Surface unbind on Android). A
+cancelled `open()` must not publish LIVE (`CameraSoftAP.shouldCommitLiveHandshake`).
+Process death did that for free; leaving the socket live is why reconnect
+hung on Waiting for live view until the app was killed.
+
+## Decoder latch
+
+Pocket 4 / 4 Pro: HEVC 720p. Nano: AVC/H.264 High 720p. Configure the
+decoder from VPS/SPS/PPS (`0x40/0x42/0x44`) or Nano AVC SPS/PPS (`0x67/0x68`).
+Leftover TRAIL P-frames and HEVC IDR_N_LP (`0x28`, also AVC PPS with
+`nal_ref_idc=1`) must not latch AVC — that threw `MediaCodec.configure` and
+left Waiting for live view up.
+
+## Foreground / SoftAP flap
+
+iOS is the operator-proven datalink (`DatalinkDriver.swift`
+`requiredLocalEndpoint` = camera DHCP IPv4; `noteSceneBecameActive` →
+`recoverAfterForeground`). Android must match that 5-tuple and lifecycle, not
+reimplement the ladder in `LiveViewEnablePolicy`.
+
+Mid-session SoftAP `onLost` is a Network-object replace until the grace
+expires — do not `bindProcessToNetwork(null)` while `isProcessBound` still
+reads true, or UDP rebuilds on home Wi-Fi.
+
+## Pointers
+
+- Stall / recover: [`feed-watchdog.md`](feed-watchdog.md)
+- Operator-visible match: [`PARITY.md`](PARITY.md)
+- Wire format: [protocol handbook live view](https://openpocketcine.app/docs/protocol/live-view/)
+  (Markdown source: `handbook/src/content/docs/protocol/live-view.md`)

--- a/docs/superpowers/plans/2026-08-23-agent-context-architecture.md
+++ b/docs/superpowers/plans/2026-08-23-agent-context-architecture.md
@@ -1,0 +1,110 @@
+# Agent context architecture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the thin `AGENTS.md` index plus disclosed `CONTEXT.md`, `docs/live-session.md`, and `docs/PARITY.md`, with Architecture and Android split so each fact has one home.
+
+**Architecture:** Always-loaded rules stay in `AGENTS.md`. Durable seams stay in `docs/ARCHITECTURE.md`. Live UDP/decoder gotchas move to `docs/live-session.md`. Operator-visible contract moves to `docs/PARITY.md`. `ANDROID.md` keeps JNI/build/I/O only. Client stubs point at `AGENTS.md` with no `@import`.
+
+**Tech Stack:** Markdown in-repo; verification is `just check` plus the spec’s grep ledger.
+
+**Spec:** `docs/superpowers/specs/2026-08-23-agent-context-architecture-design.md`
+
+## Global Constraints
+
+- Docs-only. No Swift, Kotlin, Gradle, or `justfile` changes unless a link check requires it.
+- One home per fact: after a move, delete the old copy.
+- `AGENTS.md` about 90–110 lines. No Architecture `@import` from `CLAUDE.md`.
+- Leading words: portable, enable-once, hygiene, parity, physical, seams, JNI, live-session, watchdog, naming, protocol, contributing.
+- Do not add Cursor/Copilot/Gemini/Windsurf instruction files.
+- Branch: `docs/agent-context-architecture`. Conventional Commits. No commits to `main`.
+
+## File map
+
+| File | Role |
+| --- | --- |
+| `CONTEXT.md` | Glossary only |
+| `docs/live-session.md` | Datalink/decoder runbook |
+| `docs/ARCHITECTURE.md` | Durable seams (slim) |
+| `docs/PARITY.md` | Operator-visible contract |
+| `ANDROID.md` | Android build/JNI/I/O (slim) |
+| `AGENTS.md` | Always-loaded index |
+| `CLAUDE.md`, `CODEX.md`, `GROK.md` | Pointer stubs |
+| `CONTRIBUTING.md` | One pointer sentence |
+
+---
+
+### Task 1: Glossary
+
+**Files:**
+
+- Create: `CONTEXT.md`
+
+- [ ] **Step 1: Write `CONTEXT.md`** using the spec’s term table (Core through Portable). Format: heading, one-sentence purpose, `## Language`, each term as `**Term**:` + `_Avoid_:`.
+- [ ] **Step 2: Confirm every spec term is present** (`rg -c '^\*\*(Core|Shell|Facade|Spine|SoftAP|Datalink|Enable-once|Watchdog|Chrome|Parity|Assist|Physical|Hygiene|Portable)\*\*'` → 14).
+- [ ] **Step 3: Commit** `docs: add CONTEXT.md glossary`
+
+### Task 2: Live-session runbook + slim Architecture
+
+**Files:**
+
+- Create: `docs/live-session.md`
+- Modify: `docs/ARCHITECTURE.md`
+
+- [ ] **Step 1: Write `docs/live-session.md`** with headings 5-tuple, ACK pump, Enable write, Disconnect teardown, Decoder latch, Foreground / SoftAP flap, Pointers. Copy the facts listed in the spec’s live-session section (Samsung `:9004`, `IDR_N_LP`, teardown, `bindProcessToNetwork(null)`).
+- [ ] **Step 2: Rewrite `docs/ARCHITECTURE.md`** to the spec’s trimmed layer table, six short spine steps, policy table plus `CameraSetMailbox`, shells-own-I/O paragraph, pointers to live-session / watchdog / parity / ANDROID.md / handbook. Drop `connection-reliability-plan.md` as an architecture pointer.
+- [ ] **Step 3: Ledger grep**
+
+```bash
+rg '9004|IDR_N_LP' docs/ARCHITECTURE.md   # expect no Samsung story, no IDR_N_LP
+rg '9004|IDR_N_LP' docs/live-session.md   # expect both
+```
+
+- [ ] **Step 4: Commit** `docs: split live-session runbook from architecture`
+
+### Task 3: Parity contract + slim Android
+
+**Files:**
+
+- Create: `docs/PARITY.md`
+- Modify: `ANDROID.md`
+
+- [ ] **Step 1: Write `docs/PARITY.md`** with the spec’s contract table plus a **Chrome metrics** subsection (27/20 pt drums, 0.72 plates, 17.5 dp histogram gutters, 340 dp FORMAT/COLOR host).
+- [ ] **Step 2: Slim `ANDROID.md`:** keep build structure, Pocket mapping, do-not-copy, milestone, OpenZCine patterns. Replace “Operator parity (iOS baseline)” with a pointer to `docs/PARITY.md` and short I/O bullets (Connection, Live picture, HUD glass, Assists GPU, Media decode).
+- [ ] **Step 3: Ledger grep**
+
+```bash
+rg 'Operator parity \(iOS baseline\)' ANDROID.md   # expect no matches
+rg 'Must match' docs/PARITY.md                     # expect the contract table
+```
+
+- [ ] **Step 4: Commit** `docs: extract operator parity contract from ANDROID.md`
+
+### Task 4: Always-loaded index and stubs
+
+**Files:**
+
+- Modify: `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`
+- Create: `CODEX.md`, `GROK.md`
+
+- [ ] **Step 1: Rewrite `AGENTS.md`** in spec section order: identity, stack & paths, hard rules, before you edit, read when, verification, completion, sediment. Drop the meta-check tool list and “Claude Code and Codex only.”
+- [ ] **Step 2: Rewrite `CLAUDE.md`** from the spec template (no `@import`). Add `CODEX.md` and `GROK.md` from the same template.
+- [ ] **Step 3: Add one sentence** under CONTRIBUTING Code standards: agent instructions live in `AGENTS.md`; do not copy them here.
+- [ ] **Step 4: Ledger grep**
+
+```bash
+rg '@import|ARCHITECTURE' CLAUDE.md   # expect no matches
+rg 'Read when' AGENTS.md
+rg 'CONTEXT.md|PARITY.md|live-session.md|feed-watchdog.md|commit-hygiene.md|CONTRIBUTING.md|ARCHITECTURE.md|ANDROID.md|handbook' AGENTS.md
+```
+
+- [ ] **Step 5: Commit** `docs: make AGENTS.md a thin pointer index`
+
+### Task 5: Quality gate
+
+- [ ] **Step 1: `just check`**
+- [ ] **Step 2: Fix any markdown/typos/link failures from this slice**
+- [ ] **Step 3: Confirm spec verification block** (Samsung/`IDR_N_LP` homes, no Operator parity heading, no CLAUDE `@import`, pointer table complete, no forbidden paths staged)
+- [ ] **Step 4: Commit** any lint fixes (`docs:` / `chore:`)
+
+Execution for this run: inline in the current session (user asked to continue unattended).

--- a/docs/superpowers/specs/2026-08-23-agent-context-architecture-design.md
+++ b/docs/superpowers/specs/2026-08-23-agent-context-architecture-design.md
@@ -1,7 +1,7 @@
 # Agent context architecture
 
 **Date:** 2026-08-23
-**Status:** draft, awaiting implementation-plan approval
+**Status:** implemented on `docs/agent-context-architecture`
 **Slice:** 1 of 6 (index + split the two bloated loads)
 
 OpenPocketCine’s always-loaded agent context is a thin index. Durable seams, operator

--- a/docs/superpowers/specs/2026-08-23-agent-context-architecture-design.md
+++ b/docs/superpowers/specs/2026-08-23-agent-context-architecture-design.md
@@ -1,0 +1,391 @@
+# Agent context architecture
+
+**Date:** 2026-08-23
+**Status:** draft, awaiting implementation-plan approval
+**Slice:** 1 of 6 (index + split the two bloated loads)
+
+OpenPocketCine’s always-loaded agent context is a thin index. Durable seams, operator
+parity, Android build, and live-session runbooks are disclosed behind trigger-worded
+pointers so agents get the invariant right the first time without eating the window.
+
+This is a documentation and agent-rules change. The Swift core + SwiftUI iOS + Compose
+Android architecture does not change.
+
+## Goal
+
+Agents (any client that reads `AGENTS.md`) take the same *process* every run:
+
+1. Name the surface (core, iOS shell, Android shell, docs).
+2. Load every pointer whose trigger matches.
+3. If the change is operator-visible, hold **parity** or record the exception.
+
+Humans keep a readable map. One home per fact. No second copy of the rules in a
+client stub.
+
+## Non-goals (later slices)
+
+- UX / FTUE design contract
+- `SECURITY.md` rewrite
+- Knowledge graph / graphify corpus
+- Task-graph orchestration docs (diamond, bounded loops) as a standalone system
+- Deleting `STATUS.md` / `OVERNIGHT.md` / `.planning/` (already gitignored)
+- `docs/agent/` tree, `llms.txt`, extra Cursor/Gemini/Windsurf instruction files
+- Code, Gradle, or `just` recipe changes except to fix a link this slice breaks
+
+## Constraints
+
+- `AGENTS.md` is canonical for every agent. Client stubs are pointers only.
+- Always-loaded budget: about 90–110 lines. Today `CLAUDE.md` also always-imports
+  `docs/ARCHITECTURE.md`; that import goes away (net context drop).
+- Positive phrasing first. A prohibition earns its place only as a hard gate
+  (forbidden paths, no direct commits to `main`).
+- Environment is source of truth for commands: `just` lists recipes. Do not
+  restate the meta-check tool list in `AGENTS.md`.
+- Leading words are the same tokens in `AGENTS.md`, `CONTEXT.md`, and pointers.
+- `STATUS.md`, `OVERNIGHT.md`, and `.planning/` are not current. Already gitignored.
+
+## Information hierarchy
+
+```text
+always-loaded:     AGENTS.md
+client stubs:      CLAUDE.md, CODEX.md, GROK.md  (pointer to AGENTS.md; no @import)
+disclosed:         CONTEXT.md, docs/ARCHITECTURE.md, docs/PARITY.md,
+                   ANDROID.md, docs/live-session.md, docs/feed-watchdog.md,
+                   handbook/, docs/commit-hygiene.md, CONTRIBUTING.md
+sediment:          STATUS.md, OVERNIGHT.md, .planning/,
+                   docs/connection-reliability-plan.md (dated PR plan)
+```
+
+### Always-loaded: `AGENTS.md`
+
+Order of sections (do not add others):
+
+1. Identity (2–3 lines, current opening)
+2. Stack & paths (lookup; `just` is the command index; drop the meta-check tool list)
+3. Hard rules
+4. Before you edit (steps)
+5. Read when (pointer table)
+6. Verification
+7. Completion
+8. Sediment (one short paragraph)
+
+### Hard rules (every branch)
+
+Keep the Swift core **portable**: Foundation-only protocol and business logic.
+
+Live view is **enable-once**: `0x09/0xa8` starts the stream and is the only PLI.
+After picture, further enables follow the **watchdog** only.
+
+**Hygiene:** secrets, camera Wi-Fi passwords, PII, unofficial LUT dumps, and
+`captures/`, `Osmo LUTS/`, `vendor/`, `ref/`, `.local/` stay out of git. Official
+Rec.709 cubes under `ios/OpenPocketCine/Resources/` and
+`Apps/Android/app/src/main/assets/luts/` are tracked.
+
+Work on a branch and open a PR. Conventional Commits
+(`feat:`, `fix:`, `docs:`, `chore:`, `ci:`, `build:`, `test:`).
+
+`AGENTS.md` is canonical for every agent. Client stubs (`CLAUDE.md`, `CODEX.md`,
+`GROK.md`) are pointers only — do not copy these rules into a second instruction
+file. Do not add Cursor, Copilot, Gemini, or Windsurf instruction dumps.
+
+Replace today’s “Claude Code and Codex only” paragraph with the paragraph above.
+
+### Before you edit (in-file steps)
+
+1. Name the surface: core, iOS **shell**, Android **shell**, or docs.
+2. Load every pointer whose trigger matches.
+3. If the change is operator-visible, read **parity** and touch both shells or
+   record the exception in `docs/PARITY.md`.
+
+Done when each matching pointer has been read (not when the table has been
+noticed).
+
+### Pointer table
+
+Front-load the leading word. One trigger line per file. Wording is the
+invocation; do not add a second sentence of identity the target already carries.
+
+| Pointer (write this line) | Target |
+| --- | --- |
+| **naming** — fuzzy term, new name, operator-visible copy | `CONTEXT.md` |
+| **seams** — new module, core vs shell, spine order | `docs/ARCHITECTURE.md` |
+| **parity** — chrome, assist, connection UX, one-platform feature | `docs/PARITY.md` |
+| **JNI** — Gradle, Swift-for-Android, `.so`, facade, OpenZCine pattern | `ANDROID.md` |
+| **live-session** — freeze, black feed, reconnect, UDP bind, ACK, decoder | `docs/live-session.md` |
+| **watchdog** — stall, GOP-reset grace, recover `0x09/0xa8` | `docs/feed-watchdog.md` |
+| **protocol** — DUML, BLE, opcode, pktType, HEVC/AVC payload | `handbook/src/content/docs/` |
+| **hygiene** — commit/PR that might touch secrets, LUTs, captures, identity | `docs/commit-hygiene.md` |
+| **contributing** — issues vs discussions, labels, human setup | `CONTRIBUTING.md` |
+
+Do not pointer `docs/connection-reliability-plan.md` from `AGENTS.md`. Load it
+only when executing that dated plan.
+
+### Verification and completion
+
+Keep `just check`, `just native-check`, `just android-check`.
+
+**physical:** operator-visible work is proven on a real iPhone or Android device
+for the platform changed. Simulator has no BLE or camera Wi-Fi. Compile-only is
+not done.
+
+A task is not done until `just check` is green for the paths touched, docs that
+describe the behavior are updated, **parity** is held or an exception is recorded
+in `docs/PARITY.md`, no forbidden paths are staged, and operator-visible work is
+**physical** for the platform changed.
+
+### Sediment
+
+`STATUS.md`, `OVERNIGHT.md`, and `.planning/` are local or dated notes. They are
+not current architecture. `docs/connection-reliability-plan.md` is a dated PR
+plan, not a contract.
+
+## Client stubs
+
+`CLAUDE.md`, `CODEX.md`, and `GROK.md` are 8–12 lines. They do **not**
+`@import` `AGENTS.md` or Architecture. Claude Code, Codex, and Grok already
+load root `AGENTS.md`; an extra import would double-pay. Stubs exist so a
+client that only reads its own filename still finds the pointer.
+
+Template (same body, title differs):
+
+```markdown
+# OpenPocketCine <client> guide
+
+Canonical project guidance is [`AGENTS.md`](AGENTS.md). Do not copy it here.
+
+Operator-visible UI: prove on a **physical** device. See `AGENTS.md` → Verification.
+```
+
+Claude’s current `@import AGENTS.md` and `@import docs/ARCHITECTURE.md` are
+removed.
+
+Do not add stubs for Cursor, Copilot, Gemini, or Windsurf. Those agents still
+read `AGENTS.md` if present; we do not ship a second copy of the rules under
+their filenames.
+
+## `CONTEXT.md` (repo root)
+
+Glossary only. No opcodes-as-tutorials, no file-tree, no “how to implement.”
+Format: term, one or two sentences, `_Avoid_` aliases. Include exactly these
+terms:
+
+| Term | Definition | Avoid |
+| --- | --- | --- |
+| **Core** | The portable Swift protocol and business-logic package (`OpenPocketViewCore`). | SDK, engine, shared module |
+| **Shell** | The platform app that owns I/O and UI: SwiftUI on iOS, Compose on Android. | client, frontend, app layer |
+| **Facade** | The Android JNI session boundary (`OpenPocketCineAndroidFacade`). | bridge, wrapper |
+| **Spine** | Required connection order: BLE → SoftAP → UDP datalink → live view. | pipeline, stack |
+| **SoftAP** | The camera’s Wi-Fi access point at `192.168.2.1`. | hotspot (except when naming the iOS API) |
+| **Datalink** | UDP port 9004 DUML transport between phone and camera. | media port, stream |
+| **Enable-once** | `0x09/0xa8` starts live view and is the only PLI; it is not a 1 Hz keyframe loop. | IDR loop, live-start (alone) |
+| **Watchdog** | Portable stall-and-recover policy (`FeedWatchdog`). | keepalive, heartbeat |
+| **Chrome** | Operator HUD around the picture (bars, chips, DISP), not the picture. | UI, overlay |
+| **Parity** | Operator-visible match to the iOS baseline unless `docs/PARITY.md` lists an exception. | pixel-identical, 1:1 clone |
+| **Assist** | A monitor tool on the picture (LUT, peaking, zebra, scopes, grids). | filter, effect |
+| **Physical** | Proof on a real phone. Simulator cannot exercise BLE or camera Wi-Fi. | on-device (prefer **physical**) |
+| **Hygiene** | Secrets, captures, unofficial LUTs, and PII stay out of git. | cleanliness |
+| **Portable** | Foundation-only core: no SwiftUI, UIKit, Android, Compose, or filesystem I/O. | cross-platform, shared |
+
+Do not add general programming terms (timeout, adapter, test).
+
+## Split ledger
+
+Move facts; do not leave the essay in two homes. After the split, a search for
+the Samsung `:9004` story finds it in `docs/live-session.md` only.
+
+### `docs/ARCHITECTURE.md` (durable seams)
+
+Keep:
+
+- Opening sentence (shared Swift core, native shells)
+- Layer table, trimmed (see cells below)
+- Lucide HUD glyph paragraph + `xcodegen` line
+- Connection spine as **six short steps** (one to two sentences each)
+- Policy-in-Swift table, plus a new row for `CameraSetMailbox`
+- “Shells own sockets, BLE, SoftAP, permissions, lifecycle, rendering, storage, UI”
+- Pointers to **live-session**, **watchdog**, **parity**, **JNI**, handbook
+
+Layer cells after trim:
+
+| Layer | Purpose cell |
+| --- | --- |
+| Shared core | DUML, commands, status, LUTs, layout policy. **Portable** Foundation. |
+| iOS app | SwiftUI **shell**, CoreBluetooth, NEHotspotConfiguration, sockets, VideoToolbox/Metal. Teardown: **live-session**. |
+| Android app | Compose **shell**. Live picture and HUD I/O: `ANDROID.md`. Operator-visible behavior: **parity**. Teardown: **live-session**. |
+| Android facade | Swift session and JNI boundary |
+| Tests | Swift Testing suite for the portable core |
+
+Spine after trim (invariants stay; stories leave):
+
+1. BLE scan and pair (GATT FFF0).
+2. Read camera Wi-Fi credentials.
+3. Join SoftAP `192.168.2.1`. On-path only after DHCP `192.168.2.2…254`
+   (`CameraSoftAP.isAssociatedIPv4`).
+4. UDP DUML to `192.168.2.1:9004` on an **ephemeral local port**. Camera 9004 is
+   the remote only. Bind and ACK details: **live-session**.
+5. Enable live view **enable-once** after path + display are ready. Arm pktType
+   `0x02` ingest on that write. Recover policy: **watchdog**.
+6. Pocket 4 / 4 Pro: HEVC 720p. Nano: AVC/H.264 High 720p. Decoder setup and
+   NAL latch: **live-session**.
+
+Add to the policy table:
+
+| Policy | Core type | Shell I/O |
+| --- | --- | --- |
+| Camera SET mailbox, retransmit, settle | `CameraSetMailbox` | iOS `fireCamera`; Android JNI |
+
+Remove from Architecture (move to **live-session**):
+
+- iOS disconnect-teardown sentence in the layer table
+- Android Vulkan / Kyant / scope / chrome-scale / fillCrop essay in the layer table
+- Samsung local `:9004` bind story
+- Mimo ephemeral-port citation as a narrative (the rule “ephemeral local port” stays)
+- TCP 7001 poke across UDP rebuilds
+- `0x02/0x68` payload `08`, 200 ms ACK wait, 40 Hz `0x04` ACK pump
+- Leftover GOP P-frames / in-app Disconnect driver+decoder drop / cancelled `open()`
+- TRAIL P-frames and HEVC `IDR_N_LP` (`0x28`) vs AVC latch
+- “iOS is the operator-proven datalink” 5-tuple paragraph and
+  `bindProcessToNetwork(null)` while `isProcessBound`
+- Pointer to `docs/connection-reliability-plan.md` as if it were architecture
+
+### `docs/live-session.md` (new; current datalink/decoder runbook)
+
+Title: Live session. Opening: current I/O facts for the live UDP session and
+platform decoders. Not a diary. Not the stall state machine (**watchdog** owns
+that).
+
+Must contain, as colocated headings:
+
+1. **5-tuple** — iOS binds DHCP IPv4 + ephemeral local port
+   (`NWParameters.requiredLocalEndpoint` port 0). Android
+   `bindProcessToNetwork` then UDP `0.0.0.0:0` after `Network.bindSocket`.
+   Camera `192.168.2.1:9004` is the remote only. Local `:9004` on Samsung
+   accepted handshake + `0x01` and dropped pktType `0x02`.
+2. **ACK pump** — pktType `0x04` at 40 Hz, cursor = latest video transport seq.
+   Keep TCP 7001 poke across UDP rebuilds.
+3. **Enable write** — arm pktType `0x02` ingest on the enable write; do not wait
+   for a DUML ACK (VPS is 25–167 ms). Pocket may send `0x02/0x68` payload `08`
+   immediately before `0x09/0xa8`. **Enable-once** (hard rule); further enables
+   follow **watchdog**.
+4. **Disconnect teardown** — bump `udpGeneration` / closed flag, drop callbacks
+   and ACK pump, invalidate VT + flush layer on iOS, join MediaCodec output
+   thread + unbind Surface on Android. Cancelled `open()` must not publish LIVE
+   (`CameraSoftAP.shouldCommitLiveHandshake`).
+5. **Decoder latch** — configure from VPS/SPS/PPS (`0x40/0x42/0x44`) or Nano AVC
+   SPS/PPS (`0x67/0x68`). Leftover TRAIL P-frames and HEVC `IDR_N_LP` (`0x28`)
+   must not latch AVC.
+6. **Foreground / SoftAP flap** — iOS `noteSceneBecameActive` →
+   `recoverAfterForeground`. Mid-session SoftAP `onLost` is a Network-object
+   replace until grace expires; do not `bindProcessToNetwork(null)` while
+   `isProcessBound` is still true.
+7. **Pointers** — stall/recover → `docs/feed-watchdog.md`; wire format →
+   handbook live-view; operator-visible match → `docs/PARITY.md`.
+
+Do not copy the FeedWatchdog grace table into this file.
+
+### `docs/PARITY.md` (new; operator-visible contract)
+
+Opening: iOS is the operator-proven baseline. Android matches operator-visible
+behavior unless a row lists an exception. GPU backends, Bluetooth stacks, and
+OS APIs may diverge. Shipping a one-platform operator-visible change without a
+row here is incomplete.
+
+Rule for agents: before changing an operator-visible surface, read this file.
+Ship both shells or write the exception in the table in the same PR.
+
+| Surface | Must match | May diverge | Verify |
+| --- | --- | --- | --- |
+| Connection FTUE and spine | BLE → SoftAP → UDP; **enable-once**; ephemeral local port; arm `0x02` on enable write; disconnect drops driver + decoder; session recovery holds last frame | iOS `NEHotspotConfiguration` vs Android `WifiNetworkSpecifier` + `bindProcessToNetwork`; Network.framework vs Android sockets | **physical** both |
+| Live chrome | DISP 1/2 maps, layout metrics (`LiveDesign` / `fillCrop` / screen-flip pillarbox), picker chrome, record as bottom sheet, zoom chip, gimbal 1–5 gain, rec lamp `pressShutter` | iOS Liquid Glass vs Kyant (API 33+ and ≥4 GB; else solid frost); SF Symbols / Material only where Lucide catalog has not replaced them | **physical** both |
+| Assists | Toolbar 1:1 (LUT, PEAK, FALSE, ZEBRA, WAVE, PARADE, HISTO, VECTOR, LIGHTS, AUDIO, GUIDES, GRID, CROSS, MIRROR); long-press options; WAVE hold-without-drag opens options; scope plate metrics (`ScopeMiniChrome`) | Metal vs Vulkan vs GLES; Vision vs `android.media.FaceDetector`; PixelCopy / Kyant sampling | **physical** both |
+| Camera SETs | `CameraSetMailbox` fire-and-forget + 300 ms retransmit + 2 s settle; missed ACK does not revert HUD; ISO D-Log ↔ D-Log2 hop; audio blobs and tap-focus stay round-trips | JNI vs Swift `fireCamera` | **physical** both |
+| Zoom | Chip 1×→3×→6×→12×; `CamFov` hybrid readout; pinch at 20 Hz without ACK wait; D-Log2 hops to D-Log off 1× | Hit-testing over SurfaceView vs SwiftUI | **physical** both |
+| Tracking | Long-press+drag search box `0x02/0xA6`; tap face bracket → ActiveTrack; green cancel X and focus-reset | Face detector implementation | **physical** both |
+| Operator Setup | Seven tabs (Link, Sharing, View Assist, Controls, Display, Storage, System); DJI Black; Sora + IBM Plex; NOTICE legal | Frame.io row is “Not configured” until iOS keys exist | **physical** both |
+| Media | Camera catalog, SoftAP HTTP cache, 720p LRF/XRF proxy playback, independent playback assist rail, live HEVC held while library covers the monitor | Frame.io C2C and LUT bake on export: iOS only. Android share/save uses the original (`MediaHTTP.deliveryPath`). Playback chrome is an 82% DJI-black plate (no Kyant). | **physical** both |
+| Explicit skip | — | VideoToolbox, MetalFX super-res, iOS 26 Liquid Glass API, Frame.io OAuth, LEVEL / De-SQ / MAG | n/a |
+
+Pixel-level numbers that are the contract (drum faces 27/20 pt, 0.72 plates,
+histogram gutters 17.5 dp, FORMAT/COLOR 340 dp host) live in `docs/PARITY.md`
+as a short **Chrome metrics** subsection, moved from `ANDROID.md` and not
+duplicated back.
+
+### `ANDROID.md` (build / JNI / I/O)
+
+Keep:
+
+- Title, “not on Play”, iOS is the daily driver
+- How the Android build is structured (five steps)
+- Pocket mapping table
+- Do not copy from OpenZCine Android
+- First Android milestone (short)
+- OpenZCine Android patterns adopted (Keystore, `WIFI_MODE_FULL_LOW_LATENCY`,
+  haptics, SDK 36 gate, `CubeLUT` packer, GLES fallback, media cache,
+  sticky battery)
+
+Replace the “Operator parity (iOS baseline)” essay with:
+
+- One paragraph: operator-visible behavior lives in `docs/PARITY.md`. This file
+  is the Android build and I/O notes that implement those rows.
+- I/O notes grouped by surface (Connection, Live picture, HUD glass, Assists
+  GPU, Media decode) — **how Android does it**, not the contract. Each note is
+  one or two sentences: `bindProcessToNetwork`, MediaCodec `KEY_LOW_LATENCY` /
+  wall-clock PTS, Vulkan `libopc_vulkan.so` path, Kyant hardware gate,
+  PixelCopy ~20 Hz, GLES `FeedEffectsGlProgram` fallback, ExoPlayer OES
+  playback, Wi-Fi creds in private prefs not saved-camera JSON, `holdsMonitor`
+  first-picture recover.
+
+Do not restate enable-once, ephemeral port, or mailbox semantics here. Point at
+**live-session** / **parity**. Target: `ANDROID.md` stays a build/I/O guide a
+person can read in one sitting, not a paste of the old parity essay.
+
+## Other edits in this slice
+
+- `CONTRIBUTING.md`: add one sentence under Code standards — agent instructions
+  live in `AGENTS.md`; do not copy them here. Leave the rest of CONTRIBUTING
+  alone. Deduping its standards against `AGENTS.md` is a later hygiene slice.
+- `docs/ARCHITECTURE.md` “See” links: `feed-watchdog.md`, `live-session.md`,
+  `PARITY.md`, handbook. Drop the architecture-level pointer to
+  `connection-reliability-plan.md`.
+- No README rewrite. No handbook rewrite. No `justfile` change unless a
+  markdown link check requires it.
+
+## Implementation order (for the plan, not this spec)
+
+1. Add `CONTEXT.md`.
+2. Add `docs/live-session.md` from the Architecture ledger (copy then delete).
+3. Slim `docs/ARCHITECTURE.md`.
+4. Add `docs/PARITY.md` from the Android ledger (copy then delete).
+5. Slim `ANDROID.md`.
+6. Rewrite `AGENTS.md`.
+7. Rewrite `CLAUDE.md`; add `CODEX.md` and `GROK.md`.
+8. One-line `CONTRIBUTING.md`.
+9. `just check`.
+
+One writer per file in a given step. Do not leave a fact in the old home after
+the new home exists.
+
+## Verification of this slice
+
+- `just check` (hygiene, typos, markdown, links). Docs-only: not `native-check`.
+- Grep: Samsung `:9004` and `IDR_N_LP` appear in `docs/live-session.md` and not
+  in `docs/ARCHITECTURE.md`.
+- Grep: “Operator parity (iOS baseline)” heading is gone from `ANDROID.md`.
+- `CLAUDE.md` does not mention `ARCHITECTURE.md` and has no `@import`.
+- Pointer table in `AGENTS.md` names every disclosed file in this spec.
+- Forbidden paths unstaged.
+
+## Success
+
+An agent starting a chrome change loads **parity** (and **physical**) without
+loading JNI or DUML. An agent starting a UDP freeze loads **live-session** and
+**watchdog** without loading Operator Setup. A human can onboard from `AGENTS.md`
+plus the one pointer that matches their task.
+
+## Later slices (not this PR)
+
+2–3. Parity/performance budgets as living SLOs (this slice only *extracts* the
+     contract that already lives in `ANDROID.md`).
+4. Security, OSS collaboration, sediment cleanup.
+5. UX / FTUE contract for creatives and operators.
+6. Agentic execution (task graphs, bounded loops, optional knowledge graph).


### PR DESCRIPTION
## What & why

Agents were either under-loading invariants or dumping `docs/ARCHITECTURE.md` and `ANDROID.md` into every turn (Claude always-imported Architecture). This slice makes `AGENTS.md` a thin always-loaded index with trigger-worded pointers, and gives each fact one home.

- `AGENTS.md` — hard rules + **Read when** pointers (`portable`, `enable-once`, `parity`, `live-session`, …). Canonical for every agent.
- `CONTEXT.md` — glossary only.
- `docs/ARCHITECTURE.md` — durable seams (trimmed spine + policy table, including `CameraSetMailbox`).
- `docs/live-session.md` — UDP 5-tuple, ACK pump, enable write, teardown, decoder latch, SoftAP flap.
- `docs/PARITY.md` — operator-visible must-match / may-diverge / verify contract + chrome metrics.
- `ANDROID.md` — build/JNI/I/O only.
- `CLAUDE.md` / `CODEX.md` / `GROK.md` — pointers; no `@import` of Architecture.

No app behavior change. Later slices (UX/FTUE, security rewrite, task graphs) are intentionally out of this PR.

Spec: `docs/superpowers/specs/2026-08-23-agent-context-architecture-design.md`.

## TestFlight notes

No tester-facing app behavior. Docs and agent-instruction files only.

## Checklist

- [x] `just check` passes.
- [x] Native production changes: none; docs-only (not `native-check`).
- [x] Commits follow Conventional Commits.
- [x] No captures, Wi-Fi passwords, unofficial LUT dumps, signing material, or other secrets.
- [x] Docs/CHANGELOG updated if behavior or setup changed.
- [x] TestFlight-triggering changes include reviewed `ios/TestFlight/WhatToTest.en-US.txt` copy. (N/A — no app sources changed.)
- [x] iOS release PRs: bump `MARKETING_VERSION` in `ios/Config/Version.xcconfig` when starting a new version train. (N/A.)
