### PR TITLE
docs: add performance, UX, security, and agent workflow contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ primarily **Osmo Pocket 4 / 4 Pro**, with Nano live view on AVC.
 
 ## Read when
 
-- **naming** — fuzzy term, new name, operator-visible copy: [`CONTEXT.md`](CONTEXT.md)
+- **naming** — fuzzy term, new name: [`CONTEXT.md`](CONTEXT.md)
 - **seams** — new module, core vs shell, spine order: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
 - **parity** — chrome, assist, connection UX, one-platform feature: [`docs/PARITY.md`](docs/PARITY.md)
 - **JNI** — Gradle, Swift-for-Android, `.so`, facade, OpenZCine pattern: [`ANDROID.md`](ANDROID.md)
@@ -49,6 +49,10 @@ primarily **Osmo Pocket 4 / 4 Pro**, with Nano live view on AVC.
 - **protocol** — DUML, BLE, opcode, pktType, HEVC/AVC payload: `handbook/src/content/docs/`
 - **hygiene** — commit/PR that might touch secrets, LUTs, captures, identity: [`docs/commit-hygiene.md`](docs/commit-hygiene.md)
 - **contributing** — issues vs discussions, labels, human setup: [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- **budget** — smoothness, fps, jank, HUD Hz, scope tap, ACK rate, thermal: [`docs/PERFORMANCE.md`](docs/PERFORMANCE.md)
+- **security** — vulnerability, SoftAP password, Keychain, advisory: [`SECURITY.md`](SECURITY.md)
+- **ux** — FTUE, first-run, wizard, operator copy, help, empty/error: [`docs/UX.md`](docs/UX.md)
+- **workflow** — parallel, subagent, loop, verify in a fresh context, graphify: [`docs/WORKFLOW.md`](docs/WORKFLOW.md)
 
 ## Verification
 
@@ -59,7 +63,7 @@ primarily **Osmo Pocket 4 / 4 Pro**, with Nano live view on AVC.
 
 ## Completion
 
-A task is not done until `just check` is green for the paths touched, docs that describe the behavior are updated, **parity** is held or an exception is recorded in `docs/PARITY.md`, no forbidden paths are staged, and operator-visible work is **physical** for the platform changed.
+A task is not done until `just check` is green for the paths touched, docs that describe the behavior are updated, **parity** is held or an exception is recorded in `docs/PARITY.md`, no forbidden paths are staged, and operator-visible work is **physical** for the platform changed. A live-path change also still meets **budget**.
 
 ## Sediment
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ All notable changes to this project are documented here. The format is based on
   contract lives in [`docs/PARITY.md`](docs/PARITY.md); live UDP and decoder
   facts in [`docs/live-session.md`](docs/live-session.md); glossary in
   [`CONTEXT.md`](CONTEXT.md). [`ANDROID.md`](ANDROID.md) is build/JNI/I/O only.
+  Live-path SLOs: [`docs/PERFORMANCE.md`](docs/PERFORMANCE.md). Operator UX /
+  FTUE: [`docs/UX.md`](docs/UX.md). Agent task graphs:
+  [`docs/WORKFLOW.md`](docs/WORKFLOW.md). Runtime trust boundaries:
+  [`SECURITY.md`](SECURITY.md).
 
 - Android live scopes match iOS `ScopeMiniChrome` / `WaveformMovablePanel`:
   DJI-black 72% plates (`LiveDesign.scopePlate`). WAVE / PARADE / VECTOR /

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,3 +60,11 @@ _Avoid_: cleanliness
 **Portable**:
 Foundation-only core: no SwiftUI, UIKit, Android, Compose, or filesystem I/O.
 _Avoid_: cross-platform, shared
+
+**Budget**:
+A living SLO for the live path (frame rate, ACK, HUD Hz, scope tap).
+_Avoid_: perf tweak, optimization (alone)
+
+**FTUE**:
+The first-run pairing wizard: BLE → approve → SoftAP → live picture.
+_Avoid_: onboarding, tutorial, splash (the splash is not the wizard)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,9 @@ engineering. By participating you agree to our [Code of Conduct](CODE_OF_CONDUCT
 No vendor SDK is included or required — the camera protocol is reverse-engineered from public
 behavior (see [`docs/protocol-notes.md`](docs/protocol-notes.md) and
 [openpocketcine.app/docs](https://openpocketcine.app/docs/); `just handbook` locally).
-**Never commit packet captures,
-Wi-Fi passwords, or unofficial LUT dumps.** Official Rec.709 cubes in
-`ios/OpenPocketCine/Resources/` are part of the app. See
-[`docs/commit-hygiene.md`](docs/commit-hygiene.md).
+**Hygiene** (secrets, captures, unofficial LUTs): [`docs/commit-hygiene.md`](docs/commit-hygiene.md)
+and [`AGENTS.md`](AGENTS.md). Official Rec.709 cubes in
+`ios/OpenPocketCine/Resources/` are part of the app.
 
 ### Running the app
 
@@ -40,10 +39,11 @@ Frame.io upload is **disabled unless you configure it**. Copy
 
 ## Workflow
 
-- Branch off `main` (e.g. `feat/live-view`, `fix/wifi-join`, `chore/...`).
-- Make focused commits using **[Conventional Commits](https://www.conventionalcommits.org/)**:
-  `feat:`, `fix:`, `docs:`, `chore:`, `ci:`, `build:`, `test:`, `refactor:`.
-- Run `just check` before pushing. For native iOS changes, run `just native-check`.
+Branching, Conventional Commits, and `just check` follow [`AGENTS.md`](AGENTS.md).
+Agent task graphs (split, verify, loops) live in [`docs/WORKFLOW.md`](docs/WORKFLOW.md).
+
+GitHub-specific:
+
 - Open a pull request into `main`. Actions runs on the PR, not a second time
   on the branch push. The required check is **CI gate** (Meta checks, Native
   Swift/iOS, Android, and the protocol handbook feed that gate and skip when
@@ -56,16 +56,12 @@ Frame.io upload is **disabled unless you configure it**. Copy
 ## Code standards
 
 - Agent instructions live in [`AGENTS.md`](AGENTS.md). Do not copy them here.
-- The production target is a shared Swift business/protocol core with native UI shells: SwiftUI on
-  iOS and Jetpack Compose on Android.
+  Seams: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). **Parity:** [`docs/PARITY.md`](docs/PARITY.md).
 - Composition over inheritance; prefer small pure functions and immutable data.
 - Keep functions short (~20 statements) and nesting shallow (≤3 levels) — extract helpers, use early returns.
 - Throw descriptive exceptions for errors; don't return `null` to signal failure.
 - Explicit types on all public signatures; avoid dynamic or loosely typed boundaries.
 - Use platform-native doc comments on public API members.
-- Keep the shared Swift core portable: no SwiftUI, UIKit, Android, Compose, or filesystem/UI
-  dependencies in protocol/business logic. Platform adapters own sockets, permissions, lifecycle,
-  rendering, storage, and UI.
 
 ## Reporting bugs & requesting features
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,11 @@ filmmakers and developers can inspect, improve, and adapt the tool they rely on.
 - **[Protocol handbook](https://openpocketcine.app/docs/)** — BLE pairing, camera Wi-Fi, DUML
   frames, commands, and live view. Preview locally with `just handbook`.
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — shared Swift core and platform shells
-- [`CONTRIBUTING.md`](CONTRIBUTING.md) — setup, workflow, and how to report bugs
+- [`docs/PARITY.md`](docs/PARITY.md) — operator-visible iOS / Android contract
+- [`docs/PERFORMANCE.md`](docs/PERFORMANCE.md) — live-path SLOs (frame rate, ACK, HUD)
+- [`docs/UX.md`](docs/UX.md) — FTUE, operator copy, help, failure states
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — setup, GitHub workflow, and how to report bugs
+- [`AGENTS.md`](AGENTS.md) — always-loaded index for coding agents
 
 ## Architecture
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,16 +1,51 @@
 # Security Policy
 
-OpenPocketCine controls cameras over Bluetooth and local networks, so we take security seriously.
+OpenPocketCine talks to cameras over Bluetooth and a local Wi-Fi LAN with no
+upstream internet. Treat the SoftAP passphrase, captures, and optional Frame.io
+keys as secrets.
 
 ## Supported versions
 
-The project is pre-release; only the latest `main` is supported. There are no released versions yet.
+The project is pre-release; only the latest `main` is supported.
 
 ## Reporting a vulnerability
 
 **Do not open a public issue for security vulnerabilities.**
 
-Please report privately via [GitHub Security Advisories](https://github.com/erik-sutton95/OpenPocketCine/security/advisories/new). Include reproduction steps and impact if you can.
+Report privately via
+[GitHub Security Advisories](https://github.com/erik-sutton95/OpenPocketCine/security/advisories/new).
+Include reproduction steps and impact if you can.
 
-We aim to acknowledge reports within 7 days and to keep you updated as we investigate and fix the issue.
-Coordinated disclosure is appreciated — we will credit reporters who wish to be named.
+We aim to acknowledge reports within 7 days and to keep you updated as we
+investigate and fix the issue. Coordinated disclosure is appreciated — we will
+credit reporters who wish to be named.
+
+Commit and leak hygiene (what must never enter git) lives in
+[`docs/commit-hygiene.md`](docs/commit-hygiene.md).
+
+## Trust boundaries
+
+- **BLE** is the control plane (pair, Wi-Fi creds, some SETs).
+- **Camera SoftAP** (`192.168.2.1`) is a local, internetless LAN. The phone is a
+  client. Anyone with the passphrase is on that LAN.
+- **UDP 9004** carries DUML, including live video. Video is plaintext HEVC/AVC
+  on that LAN (public camera behavior, not an app choice).
+- **Saved-camera JSON** never holds the SoftAP password. iOS keeps it in
+  Keychain (`CameraWifiKeychain`); Android in Keystore AES/GCM
+  (`CameraWifiCredentialStore`). Re-read over BLE when the store misses.
+- **Frame.io** client IDs live in gitignored `Frame.io.local.xcconfig`. The
+  feature is off without them.
+
+## Runtime rules
+
+Log phases and opcodes, not passphrases. `Documents/control-live.log` is for
+feed diagnosis on device; it is not a capture dump and it is not committed.
+
+Pairing dumps, Keychain exports, and `captures/` can contain the SoftAP
+passphrase and interiors. They stay gitignored.
+
+The app does not ship analytics or crash reporters that upload operator
+footage or identifiers.
+
+Protocol facts in the handbook come from public behavior and hardware we own —
+never from proprietary vendor documentation.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,7 +47,8 @@ Platform shells own sockets, BLE, SoftAP join, permissions, lifecycle, rendering
 storage, and UI. Do not import SwiftUI, UIKit, Android, or Compose into the core.
 
 See [`live-session.md`](live-session.md), [`feed-watchdog.md`](feed-watchdog.md),
-[`PARITY.md`](PARITY.md), and [`ANDROID.md`](../ANDROID.md).
+[`PARITY.md`](PARITY.md), [`PERFORMANCE.md`](PERFORMANCE.md), [`UX.md`](UX.md),
+and [`ANDROID.md`](../ANDROID.md).
 
 See the [protocol handbook](https://openpocketcine.app/docs/) for wire-level detail
 (Markdown source in `handbook/src/content/docs/`; stub at [`protocol-notes.md`](protocol-notes.md)).

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -22,7 +22,8 @@ write the exception in the table in the same PR.
 
 Datalink bind, ACK, enable-write, and decoder latch facts live in
 [`live-session.md`](live-session.md). Android I/O that implements these rows
-lives in [`ANDROID.md`](../ANDROID.md).
+lives in [`ANDROID.md`](../ANDROID.md). First-run copy and operator voice:
+[`UX.md`](UX.md). Live-path SLOs: [`PERFORMANCE.md`](PERFORMANCE.md).
 
 ## Chrome metrics
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,52 @@
+# Live performance budgets
+
+The picture is the product. Chrome, scopes, and SET traffic ride around it.
+Target hardware is mid/high-end: iPhone 13-class and newer; Android API 33+
+with ≥4 GB RAM (the Kyant glass gate). Prove **physical** after any live-path
+change.
+
+Numbers that already have a home stay there. This file is the SLO index and the
+rules that are not in those homes. Changing a budget is a code + docs change in
+the same PR.
+
+## Budgets
+
+| Surface | Budget | Owner |
+| --- | --- | --- |
+| Live picture | Present at the camera’s live rate. Typical Pocket/Nano SoftAP is ~25 fps 720p. Do not pace decode at 30 fps. A 4K 50p body may present 50 Hz 720p. | [`live-session.md`](live-session.md), handbook live view |
+| Window ACK | pktType `0x04` at **40 Hz**, cursor = latest video transport seq | [`live-session.md`](live-session.md) |
+| Live enable | **Enable-once.** Further enables follow the watchdog only | `AGENTS.md`, [`feed-watchdog.md`](feed-watchdog.md) |
+| Stall / recover | 2 s UDP silence is a stall; 8 s GOP grace after `0x09/0xa8`; 4 s after an AF-C SET; 5 s between enables; 60 s UDP rebuild backoff | `FeedWatchdog`, [`feed-watchdog.md`](feed-watchdog.md) |
+| HUD chrome | 5 Hz (`LiveChromeThrottle.statusInterval` = 0.2 s). REC, format, color, zoom, and the other `isImmediate` fields bypass | `LiveChromeThrottle` |
+| Scope tap | 10–15 Hz on a 213×120 downsample. Not every HEVC frame. Assists-off is one blit — no 1280×720 histogram or readback per frame | [`ANDROID.md`](../ANDROID.md) I/O; iOS present path matches the rate |
+| HUD glass sample | PixelCopy ~20 Hz when Kyant cannot sample the SurfaceView | [`ANDROID.md`](../ANDROID.md) |
+| Zoom pinch | Distinct lens ticks at 20 Hz, no ACK wait | [`PARITY.md`](PARITY.md) |
+| Battery | Sticky `ACTION_BATTERY_CHANGED` (Android); no 1 Hz poll | [`ANDROID.md`](../ANDROID.md) |
+
+## Threading
+
+UDP receive re-arms on the network queue, not after a main-actor hop. A busy HUD
+must not stop the socket.
+
+Depacketize and scope accumulation stay off the UI thread. Compose/SwiftUI
+invalidates at the HUD budget, not per video packet.
+
+Keep the last decoded frame through recover. Empty samples and
+`flushAndRemoveImage` before the next picture are a black well, not a stall.
+
+## Hardware
+
+Kyant liquid glass: API 33+ and ≥4 GB, not `isLowRamDevice`. FULL stays FULL —
+no frame-budget demote. Older / low-RAM devices stay on solid frost.
+
+Decoder prefers hardware (`c2.qti` / Exynos, VideoToolbox) over a software
+fallback. GLES `FeedEffectsGlProgram` is the Android decode fallback when
+Vulkan cannot init.
+
+`WIFI_MODE_FULL_LOW_LATENCY` stays on while live.
+
+## When this pointer fires
+
+A live-path, HUD, scope, ACK, or smoothness change. After the edit, the row you
+touched still matches its owner, and the picture is **physical** at the camera’s
+live rate on mid/high-end hardware.

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -1,0 +1,63 @@
+# Operator UX
+
+OpenPocketCine is a field monitor for DPs, camera operators, and content
+creators. Glanceable on a dark set, one-handed, reliable. It is not a consumer
+camera gallery.
+
+Operator-visible layout and metrics live in [`PARITY.md`](PARITY.md). This file
+is voice, first-run, help, and failure copy.
+
+## Voice
+
+Write for the operator, not the stack. Name the camera action. Keep it short.
+
+Operator-facing strings never name sister apps or other camera brands
+(OpenZCine, Nikon). `OperatorFacingCopyTests` enforces that on iOS; Android copy
+follows the same list.
+
+Every assist that has a long-press sheet includes help for the control the
+operator is holding (units, scale, sensitivity). Empty and error states say what
+to do next.
+
+## FTUE
+
+First pair is the wizard in `ConnectionSetupView` (Android matches):
+
+1. **FIRST RUN** — “Pair your camera.” Copy promises about a minute.
+2. BLE scan → tap a row.
+3. Approve on the Pocket if asked.
+4. Join camera Wi-Fi (OS prompt — do not hide it).
+5. Datalink → live picture.
+
+Empty store: the wizard fills the viewport. After a successful pair, the camera
+is saved; next launch is **Your cameras**. **Pair new camera** re-enters the
+wizard. Settings does not start a new pair.
+
+Pocket and Nano are separate bodies. If Bluetooth reached a different camera
+than the one tapped, say so and tell the operator to pick the matching row.
+
+Simulator cannot exercise BLE or camera Wi-Fi. Wizard and reconnect changes are
+**physical**.
+
+## Failure and reconnect
+
+Session recovery holds the last frame. A black well is a teardown or present-path
+bug, not “Waiting for live view” copy over a live socket. Teardown rules:
+[`live-session.md`](live-session.md). Stall policy: [`feed-watchdog.md`](feed-watchdog.md).
+
+Record confirmation is a bottom action sheet, not a centred dialog.
+
+Link health in the top bar is delivery (FPS chip), not RSSI.
+
+## Help surfaces
+
+- Long-press View Assist → options + help.
+- Operator Setup: seven tabs (Link, Sharing, View Assist, Controls, Display,
+  Storage, System).
+- TestFlight “What to Test” is operator copy (`docs/testflight-ci.md`).
+
+## When this pointer fires
+
+First-run, wizard, saved-camera list, operator-facing strings, assist help,
+empty/error states, or reconnect copy. Run `OperatorFacingCopyTests` when iOS
+strings change. Prove wizard and reconnect **physical**.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -1,0 +1,78 @@
+# Agent workflow
+
+How coding agents split, verify, and stop in this repository. Product architecture
+stays in [`ARCHITECTURE.md`](ARCHITECTURE.md). This file is the **task graph**.
+
+## Stop rule
+
+Split only work whose pieces never read each other’s results (for example iOS
+chrome and Android I/O behind the same **parity** row). Sequential live-session
+or watchdog work stays with one agent. One owner merges.
+
+More agents is not a strategy. Uncoordinated parallel edits on the same file are
+out of bounds.
+
+## Diamond
+
+When the work does split:
+
+```text
+        ┌─ worker (one file set) ─┐
+plan ───┼─ worker (disjoint set) ─┼─→ verify (fresh context) ─→ merge
+        └─ worker (disjoint set) ─┘
+```
+
+Verify in a **separate** context from the author. A model grading its own diff
+in the same window misses most of its own mistakes. The merge owner runs
+`just check` and the spec’s grep/ledger, not a self-report.
+
+## Human gate
+
+Put the gate where a mistake is expensive to undo, not on every step:
+
+- Merge to `main` (PR)
+- Force-push or history rewrite
+- TestFlight / store publish
+- Security advisory
+- Frame.io keys or any real secret
+
+`just check`, **physical** device proof, and the **parity** table are numbers
+that cannot argue back.
+
+## Loops
+
+Every recover/fix loop has a cap: **three** rounds on the same failure, then
+stop and report. Do not 1 Hz-retry a failed approach (same shape as
+**enable-once** on the wire).
+
+One writer per file. Routing lives in the plan; the model fills the jobs.
+
+## Knowledge graph
+
+The serving index is the **Read when** table in `AGENTS.md`. `CONTEXT.md` is the
+ontology of domain terms. That pair is the GraphRAG for this repo: single-hop
+“where does X live” is a pointer, not a graph query.
+
+A committed triple store does not earn its keep here. Lookups are “open the
+pointer.” `graphify-out/` is gitignored local scratch — never commit it.
+
+Run a local graphify pass only for **multi-hop** questions (what core types a
+chrome change must call, which docs name the same opcode). Entity types to
+extract if you do:
+
+| Type | Examples |
+| --- | --- |
+| CoreType | `FeedWatchdog`, `CameraSetMailbox`, `LiveChromeThrottle` |
+| ShellSurface | live chrome, wizard, media library |
+| PointerDoc | `docs/PARITY.md`, `docs/live-session.md` |
+| Opcode | `0x09/0xa8`, pktType `0x02` |
+| Budget | 40 Hz ACK, 5 Hz HUD |
+| Assist | LUT, WAVE, ZEBRA |
+
+Relations: `IMPLEMENTS`, `OWNS_IO`, `DOCUMENTED_IN`, `MUST_MATCH`, `MAY_DIVERGE`.
+Every fact keeps a source path. Fusion (duplicate names) before you trust a path.
+
+## When this pointer fires
+
+Parallel workers, subagents, a recover loop, “how should agents split this,” or
+a knowledge-graph / graphify request.

--- a/docs/live-session.md
+++ b/docs/live-session.md
@@ -65,5 +65,6 @@ reads true, or UDP rebuilds on home Wi-Fi.
 
 - Stall / recover: [`feed-watchdog.md`](feed-watchdog.md)
 - Operator-visible match: [`PARITY.md`](PARITY.md)
+- Live-path SLOs: [`PERFORMANCE.md`](PERFORMANCE.md)
 - Wire format: [protocol handbook live view](https://openpocketcine.app/docs/protocol/live-view/)
   (Markdown source: `handbook/src/content/docs/protocol/live-view.md`)


### PR DESCRIPTION
## What & why

Completes the remaining agent-context slices after #118. Always-loaded `AGENTS.md` stays thin; each contract is disclosed behind a trigger word.

| Slice | Pointer | File |
| --- | --- | --- |
| 2–3 Performance SLOs | **budget** | `docs/PERFORMANCE.md` — live rate, 40 Hz ACK, 5 Hz HUD, scope tap, watchdog timings, threading. Numbers stay in their owners; this is the SLO index. |
| 4 Security / OSS | **security** | `SECURITY.md` — BLE/SoftAP trust boundaries, Keychain/Keystore, no passphrase logs. `CONTRIBUTING.md` drops duplicated AGENTS hard rules. |
| 5 UX / FTUE | **ux** | `docs/UX.md` — operator voice, first-run wizard, failure/reconnect copy, help surfaces. |
| 6 Task graphs | **workflow** | `docs/WORKFLOW.md` — diamond, stop rule, human gate, 3-round loop cap, pointer-index as the knowledge graph. `graphify-out/` stays gitignored local scratch. |

Glossary: **Budget**, **FTUE**. README documentation map updated. No app behavior change.

## TestFlight notes

No tester-facing app behavior. Docs only.

## Checklist

- [x] `just check` passes.
- [x] Native production changes: none; docs-only (not `native-check`).
- [x] Commits follow Conventional Commits.
- [x] No captures, Wi-Fi passwords, unofficial LUT dumps, signing material, or other secrets.
- [x] Docs/CHANGELOG updated if behavior or setup changed.
- [x] TestFlight-triggering changes: N/A.
- [x] iOS release version bump: N/A.
