### PR TITLE
docs: make the public handbook the living app docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,6 @@ Write for camera operators. For a build with no tester-facing app behavior, say 
 - [ ] Native production changes: `just native-check` passes, or the relevant platform check is noted.
 - [ ] Commits follow Conventional Commits.
 - [ ] No captures, Wi-Fi passwords, unofficial LUT dumps, signing material, or other secrets.
-- [ ] Docs/CHANGELOG updated if behavior or setup changed.
+- [ ] Docs/CHANGELOG updated if behavior or setup changed. Public handbook pages updated when protocol, app, or setup visitors read has changed.
 - [ ] TestFlight-triggering changes include reviewed `ios/TestFlight/WhatToTest.en-US.txt` copy.
 - [ ] iOS release PRs: bump `MARKETING_VERSION` in `ios/Config/Version.xcconfig` when starting a new version train.

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,7 +1,8 @@
 name: Deploy GitHub Pages
 
-# Landing page (site/) plus the Starlight handbook at /docs/. Engineering notes
-# in docs/ are never uploaded.
+# Landing page (site/) plus the Starlight handbook at /docs/ (protocol, apps,
+# setup). Engineering contracts in docs/ (PARITY, live-session, …) are never
+# uploaded.
 on:
   push:
     branches: [main]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ primarily **Osmo Pocket 4 / 4 Pro**, with Nano live view on AVC.
 | `Apps/Android/` | Compose shell and adapters |
 | `Sources/OpenPocketCineAndroidFacade/` | Android JNI facade |
 | `docs/` | Engineering references |
-| `handbook/src/content/docs/` | Protocol handbook source |
+| `handbook/src/content/docs/` | Public docs site (apps, protocol, setup) |
 | `site/` | GitHub Pages landing |
 | `.github/` | CI and templates |
 
@@ -46,7 +46,8 @@ primarily **Osmo Pocket 4 / 4 Pro**, with Nano live view on AVC.
 - **JNI** — Gradle, Swift-for-Android, `.so`, facade, OpenZCine pattern: [`ANDROID.md`](ANDROID.md)
 - **live-session** — freeze, black feed, reconnect, UDP bind, ACK, decoder: [`docs/live-session.md`](docs/live-session.md)
 - **watchdog** — stall, GOP-reset grace, recover `0x09/0xa8`: [`docs/feed-watchdog.md`](docs/feed-watchdog.md)
-- **protocol** — DUML, BLE, opcode, pktType, HEVC/AVC payload: `handbook/src/content/docs/`
+- **protocol** — DUML, BLE, opcode, pktType, HEVC/AVC payload: `handbook/src/content/docs/protocol/`
+- **handbook** — public docs at openpocketcine.app/docs, setup, iOS/Android app pages: `handbook/src/content/docs/`
 - **hygiene** — commit/PR that might touch secrets, LUTs, captures, identity: [`docs/commit-hygiene.md`](docs/commit-hygiene.md)
 - **contributing** — issues vs discussions, labels, human setup: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - **budget** — smoothness, fps, jank, HUD Hz, scope tap, ACK rate, thermal: [`docs/PERFORMANCE.md`](docs/PERFORMANCE.md)
@@ -63,7 +64,7 @@ primarily **Osmo Pocket 4 / 4 Pro**, with Nano live view on AVC.
 
 ## Completion
 
-A task is not done until `just check` is green for the paths touched, docs that describe the behavior are updated, **parity** is held or an exception is recorded in `docs/PARITY.md`, no forbidden paths are staged, and operator-visible work is **physical** for the platform changed. A live-path change also still meets **budget**.
+A task is not done until `just check` is green for the paths touched, docs that describe the behavior are updated, **parity** is held or an exception is recorded in `docs/PARITY.md`, no forbidden paths are staged, and operator-visible work is **physical** for the platform changed. A live-path change also still meets **budget**. Protocol, app, or setup that visitors read is updated in the **handbook** (`handbook/src/content/docs/`) in the same PR — [Keeping docs current](handbook/src/content/docs/contribute/documentation.md).
 
 ## Sediment
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ All notable changes to this project are documented here. The format is based on
   FTUE: [`docs/UX.md`](docs/UX.md). Agent task graphs:
   [`docs/WORKFLOW.md`](docs/WORKFLOW.md). Runtime trust boundaries:
   [`SECURITY.md`](SECURITY.md).
+- Public handbook at [openpocketcine.app/docs](https://openpocketcine.app/docs/)
+  covers protocol, iOS and Android apps, and setup — not protocol only. Same-PR
+  update rule: `handbook/src/content/docs/contribute/documentation.md`.
 
 - Android live scopes match iOS `ScopeMiniChrome` / `WaveformMovablePanel`:
   DJI-black 72% plates (`LiveDesign.scopePlate`). WAVE / PARADE / VECTOR /

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,11 @@ engineering. By participating you agree to our [Code of Conduct](CODE_OF_CONDUCT
 3. Run `just check` to confirm a green baseline.
 
 No vendor SDK is included or required — the camera protocol is reverse-engineered from public
-behavior (see [`docs/protocol-notes.md`](docs/protocol-notes.md) and
-[openpocketcine.app/docs](https://openpocketcine.app/docs/); `just handbook` locally).
+behavior. Public docs (protocol, apps, setup):
+[openpocketcine.app/docs](https://openpocketcine.app/docs/) (`just handbook` locally).
+Keep those pages current in the same PR — see
+[Keeping docs current](https://openpocketcine.app/docs/contribute/documentation/).
+
 **Hygiene** (secrets, captures, unofficial LUTs): [`docs/commit-hygiene.md`](docs/commit-hygiene.md)
 and [`AGENTS.md`](AGENTS.md). Official Rec.709 cubes in
 `ios/OpenPocketCine/Resources/` are part of the app.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   &nbsp;·&nbsp;
   <a href="https://openpocketcine.app/">Visit openpocketcine.app</a>
   &nbsp;·&nbsp;
-  <a href="https://openpocketcine.app/docs/">Protocol handbook</a>
+  <a href="https://openpocketcine.app/docs/">Docs</a>
   &nbsp;·&nbsp;
   <a href="https://github.com/erik-sutton95/OpenPocketCine/discussions/29">Explore the roadmap</a>
 </p>
@@ -157,8 +157,9 @@ filmmakers and developers can inspect, improve, and adapt the tool they rely on.
 
 ## Documentation
 
-- **[Protocol handbook](https://openpocketcine.app/docs/)** — BLE pairing, camera Wi-Fi, DUML
-  frames, commands, and live view. Preview locally with `just handbook`.
+- **[Docs](https://openpocketcine.app/docs/)** — protocol, iOS and Android apps, and how to
+  build. Preview locally with `just handbook`. Keep them current in the same PR
+  ([standard](https://openpocketcine.app/docs/contribute/documentation/)).
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — shared Swift core and platform shells
 - [`docs/PARITY.md`](docs/PARITY.md) — operator-visible iOS / Android contract
 - [`docs/PERFORMANCE.md`](docs/PERFORMANCE.md) — live-path SLOs (frame rate, ACK, HUD)
@@ -216,7 +217,7 @@ Tooling is managed through [`just`](https://github.com/casey/just):
 ```bash
 just setup         # install meta-check tools (macOS / Homebrew)
 just               # list all recipes
-just handbook      # protocol handbook at http://127.0.0.1:4321/ (live: https://openpocketcine.app/docs/)
+just handbook      # docs at http://127.0.0.1:4321/ (live: https://openpocketcine.app/docs/)
 just check         # run repository quality checks
 just format        # format Swift sources
 just test          # run Swift package tests

--- a/handbook/README.md
+++ b/handbook/README.md
@@ -1,8 +1,12 @@
-# Protocol handbook
+# OpenPocketCine handbook
 
-Astro [Starlight](https://starlight.astro.build/) site for the OpenPocketCine
-camera protocol (BLE, SoftAP, DUML). Markdown in `src/content/docs/` is the
-source of truth for both the local site and agent tooling.
+Astro [Starlight](https://starlight.astro.build/) site for OpenPocketCine:
+protocol, iOS and Android apps, and how to build. Markdown in `src/content/docs/`
+is the public source. Engineering contracts (`docs/PARITY.md`, live-session)
+stay in the git repo and are not uploaded.
+
+When protocol, app UX, or setup changes, update the matching page in the same
+PR. Standard: `src/content/docs/contribute/documentation.md`.
 
 Published at [openpocketcine.app/docs](https://openpocketcine.app/docs/).
 Preview from the repository root:

--- a/handbook/astro.config.mjs
+++ b/handbook/astro.config.mjs
@@ -14,7 +14,7 @@ export default defineConfig({
     starlight({
       title: 'OpenPocketCine',
       description:
-        'Protocol handbook: BLE pairing, camera Wi-Fi, and DUML as implemented in OpenPocketCine.',
+        'OpenPocketCine docs: protocol, iOS and Android apps, and how to build.',
       logo: {
         src: './src/assets/icon.png',
         alt: 'OpenPocketCine',
@@ -29,9 +29,24 @@ export default defineConfig({
       ],
       sidebar: [
         {
-          label: 'Protocol',
+          label: 'Start',
           items: [
             { label: 'Overview', slug: '' },
+            { label: 'Setup and build', slug: 'guides/setup' },
+            { label: 'Keeping docs current', slug: 'contribute/documentation' },
+          ],
+        },
+        {
+          label: 'Apps',
+          items: [
+            { label: 'Architecture', slug: 'apps/architecture' },
+            { label: 'iOS', slug: 'apps/ios' },
+            { label: 'Android', slug: 'apps/android' },
+          ],
+        },
+        {
+          label: 'Protocol',
+          items: [
             { label: 'Connection spine', slug: 'protocol/connection' },
             { label: 'BLE pairing', slug: 'protocol/ble' },
             { label: 'Camera Wi-Fi', slug: 'protocol/wifi' },

--- a/handbook/src/content/docs/apps/android.md
+++ b/handbook/src/content/docs/apps/android.md
@@ -1,0 +1,39 @@
+---
+title: Android app
+description: Jetpack Compose phone shell on a cross-compiled Swift core. Not on Google Play yet. arm64-v8a only.
+---
+
+The Android app lives in `Apps/Android/`. It is an early phone shell: pairing,
+HEVC live view, GPU looks, scopes, camera writes, and media. It is **not on
+Google Play**. iOS is the daily driver.
+
+## How Swift reaches Android
+
+Business logic stays in `OpenPocketViewCore`. Android follows the OpenZCine
+pattern, not Skip/SKIE:
+
+1. Portable Swift core (no SwiftUI, UIKit, or Android imports).
+2. `OpenPocketCineAndroidFacade` — session + hand-written JNI (`@_cdecl`).
+3. Gradle `:app:stageSwiftCore` (`just android-core`) builds
+   `aarch64-unknown-linux-android29` and stages `libOpenPocketCineAndroid.so`.
+   **arm64-v8a only.** Toolchain pin: Swift **6.3.3**.
+4. Kotlin `core-api` wraps JNI. Kotlin does not pack protocol bytes.
+
+Build recipes: [Setup](../guides/setup/). The living JNI/I/O notes:
+[`ANDROID.md`](https://github.com/erik-sutton95/OpenPocketCine/blob/main/ANDROID.md).
+
+## Operator surface
+
+Chrome, assists, capture, Operator Setup, and media are meant to match iOS.
+Exceptions (Frame.io, MetalFX, iOS 26 Liquid Glass, …) are listed in
+[`docs/PARITY.md`](https://github.com/erik-sutton95/OpenPocketCine/blob/main/docs/PARITY.md).
+
+Live picture: Vulkan when the device can init it; GLES fallback. HUD liquid
+glass is Kyant on API 33+ / ≥4 GB; older or low-RAM devices stay on solid frost.
+
+Wi-Fi passwords stay in Keystore, not saved-camera JSON. Pairing and live view
+need a **physical** Android phone.
+
+## What not to copy from OpenZCine Android
+
+Nikon PTP-IP, AccessorySetupKit, OCR SSID scanner, USB-C/HDMI paths.

--- a/handbook/src/content/docs/apps/architecture.md
+++ b/handbook/src/content/docs/apps/architecture.md
@@ -1,0 +1,30 @@
+---
+title: Architecture
+description: Portable Swift protocol core with a SwiftUI iOS shell and a Jetpack Compose Android shell.
+---
+
+OpenPocketCine is a shared Swift business/protocol core with native platform
+shells. Policy lives in Swift; sockets, BLE, SoftAP join, rendering, and UI
+live in the shells.
+
+| Layer | Path | Role |
+| --- | --- | --- |
+| Shared core | `Sources/OpenPocketViewCore/` | DUML, commands, status, LUTs, layout policy. Foundation only — **portable**. |
+| iOS app | `ios/OpenPocketCine/` | SwiftUI shell, CoreBluetooth, Hotspot Configuration, VideoToolbox/Metal. |
+| Android app | `Apps/Android/app/` | Jetpack Compose shell, Vulkan/GLES live picture, MediaCodec. |
+| Android facade | `Sources/OpenPocketCineAndroidFacade/` | JNI session boundary. Android does not SPM-link the core at runtime. |
+| Tests | `Tests/OpenPocketViewCoreTests/` | Swift Testing suite for the portable core. |
+
+Both apps must call the same state machines (`CameraSoftAP`, `FeedWatchdog`,
+`SessionRecovery`, `CameraSetMailbox`). Do not clone that ladder in Kotlin.
+
+HUD glyphs are vendored Lucide SVGs (`OpcIcon` on both shells).
+
+Operator-visible behavior must match across iOS and Android unless
+[`docs/PARITY.md`](https://github.com/erik-sutton95/OpenPocketCine/blob/main/docs/PARITY.md)
+lists an exception. Live UDP/decoder facts:
+[`docs/live-session.md`](https://github.com/erik-sutton95/OpenPocketCine/blob/main/docs/live-session.md).
+The full seam table:
+[`docs/ARCHITECTURE.md`](https://github.com/erik-sutton95/OpenPocketCine/blob/main/docs/ARCHITECTURE.md).
+
+Wire format is in [Protocol](../protocol/connection/).

--- a/handbook/src/content/docs/apps/ios.md
+++ b/handbook/src/content/docs/apps/ios.md
@@ -1,0 +1,35 @@
+---
+title: iOS app
+description: SwiftUI iPhone and iPad shell. Physical device for BLE and camera Wi-Fi. TestFlight is the public beta.
+---
+
+The production iOS app is a universal iPhone and iPad SwiftUI shell in
+`ios/OpenPocketCine/`. It is the operator-proven datalink. Generate the Xcode
+project with XcodeGen — see [Setup](../guides/setup/).
+
+## What it does
+
+- Bluetooth pairing, camera Wi-Fi join, saved cameras, reconnect
+- HEVC live view on Pocket 4 / 4 Pro; AVC on Osmo Nano
+- Scopes, exposure/focus assists, framing tools, customizable DISP chrome
+- Camera writes (record, ISO, EV, zoom, gimbal on Pocket)
+- Media library, playback, LUT preview, LUT bake on export
+- Optional Frame.io Camera to Cloud when you add your own Adobe keys
+
+Verify record start/stop on the camera body until you trust the link.
+
+## Device requirements
+
+BLE, Local Network, and Hotspot Configuration do not work in the Simulator.
+Operator-visible UI changes are proven on a **physical** iPhone (and iPad when
+the layout is in play). Protocol tests (`just test`) do not need hardware.
+
+Platform notes for the wire (Hotspot Configuration, Local Network, CoreBluetooth):
+[iOS protocol notes](../protocol/ios/).
+
+## Releases
+
+Public beta: [TestFlight](https://testflight.apple.com/join/1tmt3aEB). PRs that
+change `Sources/`, `ios/`, or `Package.swift` update
+`ios/TestFlight/WhatToTest.en-US.txt` for operators. See
+[`docs/testflight-ci.md`](https://github.com/erik-sutton95/OpenPocketCine/blob/main/docs/testflight-ci.md).

--- a/handbook/src/content/docs/contribute/documentation.md
+++ b/handbook/src/content/docs/contribute/documentation.md
@@ -1,0 +1,42 @@
+---
+title: Keeping docs current
+description: Public handbook vs repo contracts. What to update in the same PR so openpocketcine.app/docs stays accurate.
+---
+
+The public site at [openpocketcine.app/docs](https://openpocketcine.app/docs/)
+is this Starlight handbook. It must stay current with the apps and the protocol.
+That is a same-PR rule, not a follow-up.
+
+## Two layers
+
+| Layer | Path | Who it is for | On Pages? |
+| --- | --- | --- | --- |
+| **Public handbook** | `handbook/src/content/docs/` | Operators, new contributors, anyone on the website | Yes — `/docs/` |
+| **Engineering contracts** | `docs/*.md`, `AGENTS.md`, `ANDROID.md` | Agents and maintainers (parity, live-session, budgets, hygiene) | No |
+
+Do not paste live-session runbooks, SoftAP passwords, or packet captures into
+the handbook. Wire facts that are safe to publish live under [Protocol](../protocol/connection/).
+Gotchas that only agents need stay in `docs/live-session.md`.
+
+## What to update when
+
+| You changed | Update in the same PR |
+| --- | --- |
+| DUML, BLE, opcode, pktType, HEVC/AVC payload | Matching page under `handbook/src/content/docs/protocol/` |
+| Operator-visible chrome, assists, connection UX | [`docs/PARITY.md`](https://github.com/erik-sutton95/OpenPocketCine/blob/main/docs/PARITY.md) **and** the [iOS](../apps/ios/) or [Android](../apps/android/) app page if the public description changed |
+| Build, toolchain, how to run | [Setup](../guides/setup/) and `CONTRIBUTING.md` if GitHub workflow changed |
+| Architecture seams (core vs shell) | [Architecture](../apps/architecture/) if the public map changed; `docs/ARCHITECTURE.md` is the seam table |
+| Live-path budgets (ACK Hz, HUD Hz) | `docs/PERFORMANCE.md` (not duplicated here) |
+| First-run / operator copy | `docs/UX.md`; handbook only if the public FTUE description changed |
+
+A task is not done until those pages match the code. Preview with `just handbook`.
+Merge to `main` deploys Pages when `handbook/` or `site/` changed.
+
+## One home per fact
+
+The handbook summarizes. The contract files own the numbers and exceptions.
+If a sentence would have to be edited in two places, keep it in the contract and
+link here.
+
+Agents: `AGENTS.md` **handbook** pointer. Human GitHub workflow:
+[`CONTRIBUTING.md`](https://github.com/erik-sutton95/OpenPocketCine/blob/main/CONTRIBUTING.md).

--- a/handbook/src/content/docs/guides/setup.md
+++ b/handbook/src/content/docs/guides/setup.md
@@ -1,0 +1,66 @@
+---
+title: Setup and build
+description: Install tooling, generate the iOS project, stage the Android Swift core, and run the quality gate.
+---
+
+`just` is the single entry point. From a clone:
+
+```bash
+just setup    # macOS / Homebrew: meta-check tools + git hooks
+just check    # hygiene, markdown, links, secrets, swift test
+```
+
+Run `just` with no arguments to list recipes. Shared protocol logic is tested
+without a camera (`just test` / `swift test`). Pairing and live view need a
+**physical** phone and an Osmo Pocket 4 / 4 Pro (Nano live view is AVC).
+
+## iOS
+
+Needs [XcodeGen](https://github.com/yonaskolov/XcodeGen) (`brew install xcodegen`):
+
+```bash
+cd ios && xcodegen generate && open OpenPocketCine.xcodeproj
+```
+
+The Simulator has no Bluetooth or camera Wi-Fi. Select a physical iPhone, set
+your Team under Signing, and enable **Hotspot Configuration** on the App ID.
+Native gate: `just native-check`.
+
+More: [iOS app](../apps/ios/).
+
+## Android
+
+Needs Android Studio / JDK 17+ and the Swift Android SDK pin in `ANDROID.md`
+(Swift 6.3.3). From the repo root:
+
+```bash
+just android-core     # cross-compile OpenPocketViewCore → jniLibs
+just android-check    # assembleDebug, unit tests, lint
+```
+
+The Compose app is **arm64-v8a only** and is not on Google Play yet. Pairing and
+live view need a physical phone. More: [Android app](../apps/android/).
+
+## This handbook
+
+```bash
+just handbook         # http://127.0.0.1:4321/
+just handbook-build   # production build
+```
+
+GitHub Pages merges the landing site and this handbook at
+[openpocketcine.app/docs](https://openpocketcine.app/docs/) when `handbook/` or
+`site/` changes on `main`.
+
+## Frame.io (optional)
+
+Disabled unless you add a gitignored Adobe Native App client ID. See
+[`docs/frameio-setup.md`](https://github.com/erik-sutton95/OpenPocketCine/blob/main/docs/frameio-setup.md)
+in the repo. No keys are committed.
+
+## Hygiene
+
+Secrets, camera Wi-Fi passwords, packet captures, and unofficial LUT dumps stay
+out of git. [`docs/commit-hygiene.md`](https://github.com/erik-sutton95/OpenPocketCine/blob/main/docs/commit-hygiene.md)
+is the gate. GitHub workflow (PRs, labels, issues vs discussions) lives in
+[`CONTRIBUTING.md`](https://github.com/erik-sutton95/OpenPocketCine/blob/main/CONTRIBUTING.md).

--- a/handbook/src/content/docs/index.mdx
+++ b/handbook/src/content/docs/index.mdx
@@ -1,25 +1,31 @@
 ---
-title: Protocol handbook
-description: BLE pairing, camera Wi-Fi, and DUML as implemented in OpenPocketCine.
+title: OpenPocketCine docs
+description: Protocol, apps, and how to build OpenPocketCine — the public handbook at openpocketcine.app/docs.
 ---
 
-OpenPocketCine is not affiliated with DJI. No DJI SDK or confidential spec is in
-this repository. The BLE pairing and camera Wi-Fi path was learned with the help
-of [Osmosis](https://github.com/KonradIT/osmosis) by Konrad Iturbe. Live view,
-monitoring, and the rest of the monitor were confirmed on hardware we own. This
-is OpenPocketCine's condensed reference — not an Osmosis port.
+OpenPocketCine is the open field monitor for DJI Osmo. These pages are the
+**public handbook**: protocol, both apps, and how to build and maintain the
+project. Markdown in `handbook/src/content/docs/` is the source. Preview with
+`just handbook`. Engineering contracts that agents follow (`docs/PARITY.md`,
+`docs/live-session.md`, …) stay in the git repo and are not uploaded here.
 
-Implementation lives in `Sources/OpenPocketViewCore/`. These pages are Markdown
-in `handbook/src/content/docs/` so people can read them as a site and agents can
-still read the source.
+OpenPocketCine is not affiliated with DJI. No DJI SDK or confidential spec is in
+this repository. Protocol facts come from public behavior and hardware we own.
 
 :::caution[Do not publish captures]
 Packet captures stay in gitignored `captures/` and are never committed. Do not
-open issues with pcaps or SoftAP passwords. Protocol facts here are from public
-behavior and hardware observation — never from proprietary DJI documentation.
+open issues with pcaps or SoftAP passwords.
 :::
 
-## The connection spine
+## Start here
+
+- [Setup and build](./guides/setup/) — `just`, Xcode, Android, quality gate
+- [Architecture](./apps/architecture/) — portable Swift core, SwiftUI, Compose
+- [iOS app](./apps/ios/) — physical device, XcodeGen, TestFlight
+- [Android app](./apps/android/) — JNI, Gradle, not on Play yet
+- [Keeping docs current](./contribute/documentation/) — what to update in the same PR
+
+## Protocol
 
 BLE is control only; bulk data goes over Wi-Fi.
 
@@ -27,14 +33,11 @@ BLE is control only; bulk data goes over Wi-Fi.
 BLE scan → GATT connect → app-pairing → read Wi-Fi creds → join AP → UDP DUML → HTTP media
 ```
 
-## Pages
-
-- [Connection spine](./protocol/connection/) — order of operations
-- [BLE pairing](./protocol/ble/) — scan, GATT, app-level pairing
-- [Camera Wi-Fi](./protocol/wifi/) — credentials over BLE, SoftAP join
-- [DUML frame](./protocol/duml-frame/) — `0x55` framing and CRCs
-- [DUML transport](./protocol/duml-transport/) — UDP 9004, TCP poke, wrapping headers
-- [Command catalog](./protocol/commands/) — set/cmd table
-- [Live view](./protocol/live-view/) — enable, HEVC/AVC, fragments
-- [HTTP media](./protocol/media/) — SoftAP `/v2` fetch, list, delete, star
-- [iOS notes](./protocol/ios/) — Hotspot Configuration, Local Network, Simulator
+- [Connection spine](./protocol/connection/)
+- [BLE pairing](./protocol/ble/)
+- [Camera Wi-Fi](./protocol/wifi/)
+- [DUML frame](./protocol/duml-frame/) · [transport](./protocol/duml-transport/)
+- [Command catalog](./protocol/commands/)
+- [Live view](./protocol/live-view/)
+- [HTTP media](./protocol/media/)
+- [iOS protocol notes](./protocol/ios/)

--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ default:
 # ── Setup ──────────────────────────────────────────────────────────────────
 # Install the meta-check tools used by `just check` (macOS / Homebrew),
 # and enable the repo's git hooks (pre-commit secret scan + proprietary guard).
-# Node is required for the protocol handbook (`just handbook`).
+# Node is required for the public handbook (`just handbook`).
 setup:
     brew install node typos-cli editorconfig-checker lychee markdownlint-cli2 actionlint gitleaks swift-format xcodegen
     git config core.hooksPath .githooks
@@ -132,7 +132,7 @@ run:
 clean:
     swift package clean
 
-# ── Protocol handbook (Astro Starlight) ────────────────────────────────────
+# ── Public handbook (Astro Starlight: protocol, apps, setup) ───────────────
 # Local preview at http://localhost:4321/. Production is /docs/ on Pages.
 
 handbook:


### PR DESCRIPTION
## What & why

We had not set a documentation standard for [openpocketcine.app/docs](https://openpocketcine.app/docs/). It was protocol-only, and agents were not required to update it.

This PR:

- Expands the Starlight handbook: **Setup**, **Architecture**, **iOS**, **Android**, and **Keeping docs current**.
- Makes the public handbook the visitor-facing docs. Engineering contracts (`docs/PARITY.md`, `docs/live-session.md`, budgets) stay in git and are **not** uploaded to Pages (gotchas, not operator docs).
- Same-PR rule: protocol, app, or setup that visitors read is updated in `handbook/src/content/docs/` before the task is done. Wired into `AGENTS.md` (**handbook** pointer + completion), the PR template, and CONTRIBUTING.

Preview: `just handbook`. Deploy is the existing Pages workflow on `handbook/**` merge to `main`.

## TestFlight notes

No tester-facing app behavior. Docs only. Site updates after merge.

## Checklist

- [x] `just check` passes.
- [x] Native production changes: none.
- [x] Commits follow Conventional Commits.
- [x] No captures, Wi-Fi passwords, unofficial LUT dumps, signing material, or other secrets.
- [x] Docs/CHANGELOG updated. Public handbook pages added.
- [x] TestFlight-triggering changes: N/A.
- [x] iOS release version bump: N/A.
