### PR TITLE
docs: define trunk-based git and v* release tags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ primarily **Osmo Pocket 4 / 4 Pro**, with Nano live view on AVC.
 - Keep the Swift core **portable**: Foundation-only protocol and business logic.
 - Live view is **enable-once**: `0x09/0xa8` starts the stream and is the only PLI. After picture, further enables follow the **watchdog** only.
 - **Hygiene:** secrets, camera Wi-Fi passwords, PII, unofficial LUT dumps, and `captures/`, `Osmo LUTS/`, `vendor/`, `ref/`, `.local/` stay out of git. Official Rec.709 cubes under `ios/OpenPocketCine/Resources/` and `Apps/Android/app/src/main/assets/luts/` are tracked.
-- Work on a branch and open a PR. Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, `ci:`, `build:`, `test:`).
+- Work on a branch (`feat/`, `fix/`, `docs/`, …) and open a PR into `main`. Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, `ci:`, `build:`, `test:`). Tags and version trains: [`docs/RELEASE.md`](docs/RELEASE.md).
 - `AGENTS.md` is canonical for every agent. Client stubs (`CLAUDE.md`, `CODEX.md`, `GROK.md`) are pointers only — do not copy these rules into a second instruction file. Do not add Cursor, Copilot, Gemini, or Windsurf instruction dumps.
 
 ## Before you edit
@@ -53,6 +53,7 @@ primarily **Osmo Pocket 4 / 4 Pro**, with Nano live view on AVC.
 - **security** — vulnerability, SoftAP password, Keychain, advisory: [`SECURITY.md`](SECURITY.md)
 - **ux** — FTUE, first-run, wizard, operator copy, help, empty/error: [`docs/UX.md`](docs/UX.md)
 - **workflow** — parallel, subagent, loop, verify in a fresh context, graphify: [`docs/WORKFLOW.md`](docs/WORKFLOW.md)
+- **release** — tag, version bump, TestFlight train, `develop` / Git Flow: [`docs/RELEASE.md`](docs/RELEASE.md)
 
 ## Verification
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,8 @@ All notable changes to this project are documented here. The format is based on
   Live-path SLOs: [`docs/PERFORMANCE.md`](docs/PERFORMANCE.md). Operator UX /
   FTUE: [`docs/UX.md`](docs/UX.md). Agent task graphs:
   [`docs/WORKFLOW.md`](docs/WORKFLOW.md). Runtime trust boundaries:
-  [`SECURITY.md`](SECURITY.md).
+  [`SECURITY.md`](SECURITY.md). Git and version trains:
+  [`docs/RELEASE.md`](docs/RELEASE.md).
 
 - Android live scopes match iOS `ScopeMiniChrome` / `WaveformMovablePanel`:
   DJI-black 72% plates (`LiveDesign.scopePlate`). WAVE / PARADE / VECTOR /

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ Frame.io upload is **disabled unless you configure it**. Copy
 ## Workflow
 
 Branching, Conventional Commits, and `just check` follow [`AGENTS.md`](AGENTS.md).
+Git and version trains: [`docs/RELEASE.md`](docs/RELEASE.md) (`main` + short PRs + `v*` tags; no `develop`).
 Agent task graphs (split, verify, loops) live in [`docs/WORKFLOW.md`](docs/WORKFLOW.md).
 
 GitHub-specific:

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ filmmakers and developers can inspect, improve, and adapt the tool they rely on.
 - [`docs/PARITY.md`](docs/PARITY.md) — operator-visible iOS / Android contract
 - [`docs/PERFORMANCE.md`](docs/PERFORMANCE.md) — live-path SLOs (frame rate, ACK, HUD)
 - [`docs/UX.md`](docs/UX.md) — FTUE, operator copy, help, failure states
+- [`docs/RELEASE.md`](docs/RELEASE.md) — `main` + PRs + `v*` tags (no Git Flow)
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — setup, GitHub workflow, and how to report bugs
 - [`AGENTS.md`](AGENTS.md) — always-loaded index for coding agents
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,84 @@
+# Git and releases
+
+Trunk-based GitHub Flow. One long-lived branch (`main`), short-lived PRs, annotated
+**`v*`** tags for product trains. Not Git Flow: there is no `develop` branch, no
+standing `release/*`, and no `git-flow` CLI.
+
+This matches how the repo already ships: PRs into `main`, squash merge, linear
+history, **CI gate**, TestFlight from `main`. See
+[`repository-settings.md`](repository-settings.md) and
+[`testflight-ci.md`](testflight-ci.md).
+
+## Branches
+
+| Branch | Lifetime | Purpose |
+| --- | --- | --- |
+| `main` | Forever | Only long-lived branch. Protected. Never commit here. |
+| `feat/…`, `fix/…`, `docs/…`, `chore/…`, `ci/…`, `test/…` | One PR | Work. Name matches the Conventional Commit type. |
+| `release/x.y` or `hotfix/x.y.z` | Until tagged | **Exception only** — see below. |
+
+Open a PR into `main`. CI runs on the PR, not a second time on the branch push.
+Squash merge. Delete the head branch (GitHub already does this).
+
+Agents: same rules. Do not push `main`. Do not create tags (human gate).
+
+## Version numbers
+
+One **product** semver for iOS and Android. Two **store** counters.
+
+| Field | Source | Example |
+| --- | --- | --- |
+| Product version | iOS `MARKETING_VERSION` in `ios/Config/Version.xcconfig` **and** Android `openpocketcine.versionName` in `Apps/Android/gradle.properties` | `0.1.0` |
+| iOS build | Xcode Cloud counter (`CURRENT_PROJECT_VERSION` locally is not the cloud stamp) | `42` |
+| Android build | `openpocketcine.versionCode` in `Apps/Android/gradle.properties` | `7` |
+
+Keep `MARKETING_VERSION` and `openpocketcine.versionName` equal. Testers see
+`0.1.0 (42)` on iOS and `0.1.0 (7)` on Android — same train, different builds.
+
+Bump the product version only when starting a new train (`0.1.0` → `0.2.0`).
+Daily TestFlight uploads stay on the current train. The first external TestFlight
+build of a new marketing version needs TestFlight App Review.
+
+Bump `versionCode` when shipping an Android artifact that must exceed a previous
+install (Play / internal testing). iOS build numbers are the cloud counter.
+
+```bash
+just ios-version
+```
+
+## Tags
+
+Tags mark **trains**, not every TestFlight or CI run. Annotated, from `main`:
+
+```bash
+git checkout main && git pull
+git tag -a v0.2.0 -m "OpenPocketCine 0.2.0"
+git push origin v0.2.0
+```
+
+Then a GitHub Release from that tag. Changelog: move `[Unreleased]` entries under
+`## [0.2.0] - YYYY-MM-DD` in the same version-bump PR.
+
+One tag for both platforms (`v0.2.0`). Do not cut `ios/0.2.0` and `android/0.2.0`
+unless the apps actually ship different product versions — they share the Swift
+core, so they should not.
+
+Do not tag `v0.1.0` retroactively unless you are cutting that train on purpose.
+
+## Hotfix / freeze (rare)
+
+A `release/x.y` or `hotfix/x.y.z` branch exists only when **all** of these hold:
+
+- Testers (or Play) are on `x.y` / `x.y.z`
+- `main` already has work that must not ship on that train
+- A fix must land on the shipped train anyway
+
+Branch from the train tag (or from `main` if it still *is* that train). PR the
+fix into the release branch **and** into `main`. Tag, then delete the branch.
+This is not a standing `develop`.
+
+## Contributors
+
+When a second person gets write access, turn **admin enforcement** on for `main`
+([`repository-settings.md`](repository-settings.md)). Required review then
+applies to everyone, including the original maintainer.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -32,6 +32,7 @@ Put the gate where a mistake is expensive to undo, not on every step:
 
 - Merge to `main` (PR)
 - Force-push or history rewrite
+- Annotated `v*` tags and GitHub Releases
 - TestFlight / store publish
 - Security advisory
 - Frame.io keys or any real secret

--- a/docs/repository-settings.md
+++ b/docs/repository-settings.md
@@ -14,6 +14,8 @@ changes through the API or
 - Admin enforcement is off so the solo maintainer can merge their own PRs
   after CI. Do not give anyone else write access without turning admin
   enforcement on.
+- No `develop` branch. Feature work is PRs into `main`; product trains are
+  annotated `v*` tags. See [`RELEASE.md`](RELEASE.md).
 
 ## Actions
 

--- a/docs/testflight-ci.md
+++ b/docs/testflight-ci.md
@@ -86,7 +86,9 @@ just testflight-notes
 | **Build number** (TestFlight “Build”) | Xcode Cloud counter | `1`, `2`, … |
 
 Keep the marketing version stable so uploads stay in the same TestFlight version train. Bump
-`MARKETING_VERSION` only when starting a new train (`0.1.0` → `0.2.0`). The first external build
+`MARKETING_VERSION` only when starting a new train (`0.1.0` → `0.2.0`), and keep Android
+`openpocketcine.versionName` equal. Product tags are `v0.2.0` on `main`, not a tag per
+cloud build. See [`RELEASE.md`](RELEASE.md). The first external build
 of a version needs [TestFlight App Review](https://developer.apple.com/help/glossary/testflight-app-review/);
 later builds of that version often do not.
 


### PR DESCRIPTION
## What & why

Codify GitHub Flow instead of Git Flow. `main` stays the only long-lived branch. Short `feat/` / `fix/` / `docs/` PRs. One product semver (`MARKETING_VERSION` = Android `versionName`). Annotated **`v0.2.0`** tags for trains, not per TestFlight build, not `ios/` vs `android/` tags.

`release/x.y` / `hotfix/x.y.z` exist only when testers are on an old train and `main` has unshippable work.

Contract: [`docs/RELEASE.md`](https://github.com/erik-sutton95/OpenPocketCine/blob/docs/release-flow/docs/RELEASE.md). Pointers in `AGENTS.md` (**release**), CONTRIBUTING, TestFlight docs, WORKFLOW human gate.

Independent of #120 (handbook expansion).

## TestFlight notes

No tester-facing app behavior. Docs only. Does not cut a tag.

## Checklist

- [x] `just check` passes.
- [x] Native production changes: none.
- [x] Commits follow Conventional Commits.
- [x] No captures, secrets, or unofficial LUT dumps.
- [x] Docs/CHANGELOG updated.
- [x] TestFlight-triggering changes: N/A.
- [x] iOS release version bump: N/A.
