### PR TITLE
feat: add an Android closed-beta waitlist on the landing page

### DIFF
--- a/ANDROID.md
+++ b/ANDROID.md
@@ -1,8 +1,9 @@
 # Android — sharing Swift the OpenZCine way
 
 OpenPocketCine’s Android app lives in this repository (`Apps/Android/`,
-`Sources/OpenPocketCineAndroidFacade/`). It is **not on Google Play yet**. iOS is
-the daily driver.
+`Sources/OpenPocketCineAndroidFacade/`). It is **not on Google Play yet**. The
+closed-beta waitlist is on [openpocketcine.app](https://openpocketcine.app/). iOS
+is the daily driver.
 
 Business logic stays in **`OpenPocketViewCore`** (UI-free, I/O-free Foundation).
 Android follows the public [OpenZCine](https://github.com/erik-sutton95/OpenZCine)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- Android closed-beta waitlist on the landing page. The Android CTA opens a dialog
+  with the Tally signup (email required; Osmo and phone optional). Submissions stay
+  in Tally, not git.
+
 - Android playback LUT / PEAK / FALSE / ZEBRA grade in GLES on the 720p proxy
   (ExoPlayer → OES surface → `FeedEffectsGlProgram` → TextureView), same order
   as live. WAVE / HISTO tap that GL copy, not a TextureView `getBitmap`. Export

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ captured today for **Osmo Pocket 4 / 4 Pro** (HEVC) and, on iOS, **Osmo Nano** (
 bodies can show up in Bluetooth scan; Action and 360 live view is not captured yet.
 
 iOS (iPhone and iPad) is the daily driver. Android lives in this repository as an early phone shell
-and is not on Google Play.
+and is not on Google Play yet. The closed-beta waitlist is on
+[openpocketcine.app](https://openpocketcine.app/).
 
 - **Read the image like a colorist.** Waveform, RGB parade, histogram, and vectorscope run live on
   the iOS monitor.
@@ -134,7 +135,8 @@ when Camera to Cloud is configured.
 - Universal iPhone and iPad app (one adaptive monitor; pairing uses a wider two-column layout)
 
 The native Android implementation lives in this repository as a phone shell with live pairing,
-HEVC live view, and GPU LUT / peaking / false colour / zebra on the feed. It is not on Google Play.
+HEVC live view, and GPU LUT / peaking / false colour / zebra on the feed. It is not on Google Play
+yet; the closed-beta waitlist is on [openpocketcine.app](https://openpocketcine.app/).
 Clip export LUT bake and GPU scopes are iOS today.
 
 Captured live view: **Osmo Pocket 4 / 4 Pro**, and **Osmo Nano** on iOS. Other Osmo models may

--- a/handbook/src/content/docs/apps/android.md
+++ b/handbook/src/content/docs/apps/android.md
@@ -1,11 +1,12 @@
 ---
 title: Android app
-description: Jetpack Compose phone shell on a cross-compiled Swift core. Not on Google Play yet. arm64-v8a only.
+description: Jetpack Compose phone shell on a cross-compiled Swift core. Closed beta waitlist on the site. arm64-v8a only.
 ---
 
 The Android app lives in `Apps/Android/`. It is an early phone shell: pairing,
 HEVC live view, GPU looks, scopes, camera writes, and media. It is **not on
-Google Play**. iOS is the daily driver.
+Google Play yet**. Join the closed-beta waitlist on
+[openpocketcine.app](https://openpocketcine.app/). iOS is the daily driver.
 
 ## How Swift reaches Android
 

--- a/handbook/src/content/docs/guides/setup.md
+++ b/handbook/src/content/docs/guides/setup.md
@@ -38,8 +38,9 @@ just android-core     # cross-compile OpenPocketViewCore → jniLibs
 just android-check    # assembleDebug, unit tests, lint
 ```
 
-The Compose app is **arm64-v8a only** and is not on Google Play yet. Pairing and
-live view need a physical phone. More: [Android app](../apps/android/).
+The Compose app is **arm64-v8a only** and is not on Google Play yet. The
+closed-beta waitlist is on [openpocketcine.app](https://openpocketcine.app/).
+Pairing and live view need a physical phone. More: [Android app](../apps/android/).
 
 ## This handbook
 

--- a/site/assets/app.css
+++ b/site/assets/app.css
@@ -747,6 +747,67 @@ h3 { font-size: clamp(20px, 2.2vw, 24px); line-height: 1.25; letter-spacing: -0.
 .cta-final h2 { margin-bottom: 12px; }
 .cta-final .hero__cta { margin-top: 24px; }
 
+.beta-dialog {
+  width: min(calc(100% - 32px), 480px);
+  max-height: min(90vh, 820px);
+  margin: auto;
+  padding: 0;
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-lg);
+  background: var(--night);
+  color: #F4F6F8;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.55);
+}
+.beta-dialog::backdrop { background: rgba(0, 0, 0, 0.72); }
+.beta-dialog__panel {
+  position: relative;
+  padding: 28px 24px 20px;
+  overflow: auto;
+  max-height: min(90vh, 820px);
+}
+.beta-dialog__panel .kicker { margin-bottom: 10px; }
+.beta-dialog__panel h2 {
+  font-size: clamp(24px, 3.4vw, 32px);
+  margin-bottom: 10px;
+}
+.beta-dialog__panel .lead {
+  margin: 0 0 18px;
+  font-size: 15px;
+  max-width: none;
+}
+.beta-dialog__close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 36px;
+  height: 36px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--silver);
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+}
+.beta-dialog__close:hover,
+.beta-dialog__close:focus-visible { color: #fff; background: rgba(244, 246, 248, 0.08); }
+.beta-dialog__form {
+  display: block;
+  width: 100%;
+  height: min(32rem, 58vh);
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color-scheme: light;
+}
+.beta-dialog__legal {
+  margin-top: 14px;
+  font-size: 12px;
+  color: var(--titan);
+}
+.beta-dialog__legal a { color: var(--sky); }
+.beta-dialog__legal a:hover { text-decoration: underline; }
+
 .lineup__intro { text-align: center; margin-bottom: clamp(36px, 5vw, 56px); }
 .lineup__intro .lead { margin: 12px auto 0; }
 .lineup {

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -305,6 +305,49 @@
     });
   }
 
+  // ---- Android closed-beta waitlist: native dialog, Tally iframe, no widget JS ----
+  function initAndroidBeta() {
+    const dialog = document.getElementById("android-beta");
+    if (!dialog || typeof dialog.showModal !== "function") return;
+
+    const frame = dialog.querySelector(".beta-dialog__form");
+    const embedSrc = frame ? frame.getAttribute("src") : "";
+    let lastOpener = null;
+
+    const open = (opener) => {
+      lastOpener = opener;
+      if (frame && embedSrc) frame.src = embedSrc;
+      dialog.showModal();
+      const title = document.getElementById("android-beta-title");
+      if (title) title.focus();
+    };
+    const close = () => {
+      if (dialog.open) dialog.close();
+    };
+
+    document.addEventListener("click", (e) => {
+      const opener = e.target.closest("[data-android-beta]");
+      if (opener) {
+        e.preventDefault();
+        open(opener);
+        return;
+      }
+      if (e.target.closest("[data-android-beta-close]")) close();
+    });
+
+    dialog.addEventListener("click", (e) => {
+      const r = dialog.getBoundingClientRect();
+      const inside =
+        e.clientX >= r.left && e.clientX <= r.right &&
+        e.clientY >= r.top && e.clientY <= r.bottom;
+      if (!inside) close();
+    });
+
+    dialog.addEventListener("close", () => {
+      if (lastOpener && typeof lastOpener.focus === "function") lastOpener.focus();
+    });
+  }
+
   function init() {
     initAnchors();
     initNavMorph();
@@ -313,6 +356,7 @@
     initHero();
     initJourney();
     initRows();
+    initAndroidBeta();
   }
 
   if (document.readyState === "loading") {

--- a/site/index.html
+++ b/site/index.html
@@ -8,7 +8,7 @@
   <meta name="description" content="OpenPocketCine is a free, open-source field-monitor app for DJI Osmo. Tested on Pocket 4P. Pocket 4 and 3 are untested; Action 6 and Nano are planned.">
   <meta name="theme-color" content="#141414">
   <meta name="referrer" content="no-referrer">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-src https://tally.so; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
 
   <link rel="canonical" href="https://openpocketcine.app/">
   <meta property="og:type" content="website">
@@ -62,9 +62,7 @@
         <div class="hero__cta" data-intro>
           <a class="btn btn--primary btn--magnetic" href="https://testflight.apple.com/join/1tmt3aEB" target="_blank" rel="noopener"><span class="btn__rec" aria-hidden="true"></span>Join TestFlight</a>
           <a class="btn btn--ghost" href="https://github.com/erik-sutton95/OpenPocketCine" target="_blank" rel="noopener">★ Star on GitHub</a>
-          <span class="btn btn--disabled" data-coming-soon="android" aria-disabled="true">
-            Android <span class="btn__status">Coming soon</span>
-          </span>
+          <a class="btn btn--ghost btn--magnetic" href="https://tally.so/r/xX8eek" data-android-beta>Join Android beta</a>
         </div>
       </div>
       <div class="hero__stage" data-intro>
@@ -247,7 +245,7 @@
           </article>
         </div>
         <div class="lineup__meta">
-          <p>iPhone and iPad today. Android soon.</p>
+          <p>iPhone and iPad today. Android is a closed beta waitlist.</p>
         </div>
       </div>
     </section>
@@ -255,13 +253,11 @@
     <section class="section band band--dark" id="download" data-band="dark">
       <div class="container cta-final">
         <h2>Source is on GitHub.</h2>
-        <p class="lead">Issues and pull requests are welcome. iOS is on TestFlight. Android is not out yet.</p>
+        <p class="lead">Issues and pull requests are welcome. iOS is on TestFlight. Android is a closed beta waitlist.</p>
         <div class="hero__cta">
           <a class="btn btn--primary btn--magnetic" href="https://testflight.apple.com/join/1tmt3aEB" target="_blank" rel="noopener"><span class="btn__rec" aria-hidden="true"></span>Join TestFlight</a>
           <a class="btn btn--ghost" href="https://github.com/erik-sutton95/OpenPocketCine" target="_blank" rel="noopener">★ Star on GitHub</a>
-          <span class="btn btn--disabled" data-coming-soon="android" aria-disabled="true">
-            Android <span class="btn__status">Coming soon</span>
-          </span>
+          <a class="btn btn--ghost btn--magnetic" href="https://tally.so/r/xX8eek" data-android-beta>Join Android beta</a>
         </div>
       </div>
     </section>
@@ -289,6 +285,23 @@
       </p>
     </div>
   </footer>
+
+  <dialog class="beta-dialog" id="android-beta" aria-labelledby="android-beta-title">
+    <div class="beta-dialog__panel">
+      <button type="button" class="beta-dialog__close" data-android-beta-close aria-label="Close">
+        <span aria-hidden="true">×</span>
+      </button>
+      <span class="kicker">Android</span>
+      <h2 id="android-beta-title" tabindex="-1">Join the closed beta</h2>
+      <p class="lead">Use the Google account email you&rsquo;ll install from Play. Osmo and phone are optional. Android is 64-bit (arm64) only.</p>
+      <iframe class="beta-dialog__form"
+        title="Android closed beta signup"
+        src="https://tally.so/embed/xX8eek?alignLeft=1&amp;hideTitle=1&amp;transparentBackground=1"
+        loading="lazy"
+        referrerpolicy="no-referrer"></iframe>
+      <p class="beta-dialog__legal">Used only to add testers in Play Console. <a href="/privacy/">Privacy</a>.</p>
+    </div>
+  </dialog>
 
   <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"
     integrity="sha384-g4NTh/Iv5PPU4xPyhEWqPcwtNXOvdaDI8LLnyYfyNZOjKJeYQyjzQ9X5275eBjpt"

--- a/site/privacy/index.html
+++ b/site/privacy/index.html
@@ -59,7 +59,7 @@
       <div class="container legal-article">
         <span class="kicker">Privacy policy</span>
         <h1>Your footage is nobody's business.</h1>
-        <p class="legal-updated">Last updated: August 20, 2026</p>
+        <p class="legal-updated">Last updated: August 23, 2026</p>
       </div>
     </section>
 
@@ -127,6 +127,13 @@
           <strong>GitHub.</strong> If you open an issue or discussion, that is public and governed
           by GitHub's policies. Never post camera Wi-Fi passwords, captures, or private media.
         </li>
+        <li>
+          <strong>Tally (optional website waitlist).</strong> If you join the Android closed beta
+          from this website, Tally stores the email and any Osmo or device notes you submit.
+          Tally's
+          <a href="https://tally.so/help/privacy-policy" target="_blank" rel="noopener">privacy policy</a>
+          applies to that storage. We do not run that form ourselves.
+        </li>
       </ul>
 
       <h2>What the app does not do</h2>
@@ -136,6 +143,20 @@
         <li>No account with us &mdash; the app has no sign-up.</li>
         <li>No sale of personal data.</li>
       </ul>
+
+      <h2>Website waitlist</h2>
+      <p>
+        The app still has no account. This website has an optional Android closed-beta waitlist.
+        If you submit it, we receive your <strong>email</strong> (the Google account that will
+        install from Play) and any <strong>Osmo</strong> or <strong>phone/tablet</strong> notes
+        you include. That data is used only to add you as a tester in Google Play closed testing.
+        It is not a newsletter, not an app account, and not sold.
+      </p>
+      <p>
+        To ask that a waitlist row be deleted, open a
+        <a href="https://github.com/erik-sutton95/OpenPocketCine/discussions/new?category=q-a" target="_blank" rel="noopener">GitHub Discussion</a>
+        with the email you used. Do not post camera passwords or private media there.
+      </p>
 
       <h2>Changes and contact</h2>
       <p>

--- a/site/support/index.html
+++ b/site/support/index.html
@@ -144,7 +144,7 @@
           <details><summary>Wi-Fi join never finishes</summary><div><p>Approve the iOS Join prompt for the camera’s SoftAP. If iOS stays on cellular, forget the network and retry. Local Network permission is required for the datalink.</p></div></details>
           <details><summary>Live view stalls or never starts</summary><div><p>Move closer to the camera, confirm you are on the camera Wi-Fi, and reconnect. The monitor needs a first HEVC frame before chrome is useful.</p></div></details>
           <details><summary>A setting will not change</summary><div><p>Some writes are still reverse-engineered and can ACK, lag, or no-op. Confirm record, exposure, and media on the Pocket body. Do not treat the on-screen REC control as armed until you trust that build.</p></div></details>
-          <details><summary>Android</summary><div><p>Android is in progress. iPhone and iPad are the supported platforms today.</p></div></details>
+          <details><summary>Android</summary><div><p>Android is a closed beta. Join the waitlist from the <a href="/">home page</a> or <a href="https://tally.so/r/xX8eek" target="_blank" rel="noopener">the signup form</a>. iPhone and iPad are the daily driver today.</p></div></details>
         </div>
       </div>
     </section>

--- a/site/terms/index.html
+++ b/site/terms/index.html
@@ -59,7 +59,7 @@
       <div class="container legal-article">
         <span class="kicker">Terms of use</span>
         <h1>Short, because there's not much to agree to.</h1>
-        <p class="legal-updated">Last updated: August 18, 2026</p>
+        <p class="legal-updated">Last updated: August 23, 2026</p>
       </div>
     </section>
 
@@ -74,8 +74,8 @@
       <p>
         OpenPocketCine is free and open source, licensed under the
         <a href="https://github.com/erik-sutton95/OpenPocketCine/blob/main/LICENSE" target="_blank" rel="noopener">Apache
-        License 2.0</a>. The full source code is public. There are no accounts, no fees, and no
-        subscriptions.
+        License 2.0</a>. The full source code is public. There are no app accounts, no fees, and no
+        subscriptions. The optional Android waitlist on this website is not an app account.
       </p>
       <p>
         If you install the app from the App Store, that binary is additionally subject to Apple's


### PR DESCRIPTION
## What & why

The landing page Android control was a disabled “Coming soon” pill. It now opens a dialog with the Tally closed-beta form (`tally.so/r/xX8eek`): required Google Play email, optional Osmo checkboxes, optional phone/tablet. Submissions stay in Tally (not git) so testers can be added in Play Console.

The overlay is a native `<dialog>` and a Tally iframe — no Tally widget script (the site requires SRI on every external script). With JS off, the same buttons are links to the Tally form. Privacy and Terms disclose the website waitlist separately from the app (which still has no account). Support, README, ANDROID.md, and the handbook Android/setup pages point at it.

## TestFlight notes

No tester-facing iOS app behavior. Landing page and public docs only.

## Checklist

- [x] `just check` passes.
  - Site, markdown, and secret scan on the touched paths. Native/Android gates are unchanged.
- [x] Native production changes: `just native-check` passes, or the relevant platform check is noted.
  - Skip: no iOS or Android app code.
- [x] Commits follow Conventional Commits.
- [x] No captures, Wi-Fi passwords, unofficial LUT dumps, signing material, or other secrets.
- [x] Docs/CHANGELOG updated if behavior or setup changed.
- [x] TestFlight-triggering changes include reviewed `ios/TestFlight/WhatToTest.en-US.txt` copy.
  - N/A — this does not trigger a TestFlight build.
- [ ] iOS release PRs: bump `MARKETING_VERSION` in `ios/Config/Version.xcconfig` when starting a new version train.
  - N/A