### PR TITLE
fix: raise live scope tap to 25 Hz so traces track the picture

### DIFF
--- a/ANDROID.md
+++ b/ANDROID.md
@@ -77,7 +77,8 @@ Operator Setup, and media list rows stay solid fills.
 
 Assists-off is one YCbCr blit of the MediaCodec AHB (hardware `c2.qti` / Exynos
 HEVC, not `c2.android`). LUT / FALSE / ZEBRA add the grade pass. WAVE / PARADE /
-VECTOR / HISTO tap a 213×120 downsample at 10–15 Hz and paint in Compose Canvas.
+VECTOR / HISTO tap a 200-wide downsample (213×120 on 720p) at 25 Hz
+(10 Hz with three or more scopes) and paint in Compose Canvas.
 WAVE / PARADE accumulate into a 250×153 bitmap off the UI thread; VECTOR uses
 the 128-bin raster.
 

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/LiveViewScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/LiveViewScreen.kt
@@ -211,6 +211,7 @@ fun LiveViewScreen(model: AppModel) {
         remember {
             if (OpcVulkan.isAvailable) {
                 LiveVulkanSession(
+                    context = context,
                     onDecoderSurface = { model.session.attachSurface(it) },
                     onFirstFrame = { model.session.noteLiveFrame() },
                     onFailed = { vulkanFailed = true },

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/feed/LiveFeedEffectsSession.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/feed/LiveFeedEffectsSession.kt
@@ -127,7 +127,7 @@ internal class LiveFeedEffectsSession(
 
     /**
      * After present. Downsample the OES frame to the iOS tap size, walk it off
-     * the GL thread at 15 Hz (10 Hz with three or more scopes).
+     * the GL thread at 25 Hz (10 Hz with three or more scopes).
      */
     private fun maybeTapScopes(
         policy: ScopeTapPolicy,
@@ -192,6 +192,11 @@ internal class LiveFeedEffectsSession(
                     )
                 previousBundle = sampled
                 mainHandler.post { LiveScopeSampleBus.publish(sampled) }
+                ScopeTapHzLog.note(
+                    TAG,
+                    scopes = policy.activeScopeCount,
+                    intervalNs = PocketScopeSampler.minIntervalNs(policy.activeScopeCount, thermal),
+                )
             } catch (error: Exception) {
                 Log.w(TAG, "scope tap failed", error)
             } finally {

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/feed/LiveScopeSampleBus.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/feed/LiveScopeSampleBus.kt
@@ -1,6 +1,8 @@
 package com.opencapture.openpocketcine.feed
 
+import android.util.Log
 import androidx.compose.runtime.getValue
+import java.util.Locale
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -24,6 +26,35 @@ object LiveScopeSampleBus {
     fun reset() {
         bundle = ScopeAssistBundle.EMPTY
         generation = 0
+        ScopeTapHzLog.reset()
+    }
+}
+
+/** 2 s delivered-Hz breadcrumb vs [PocketScopeSampler.minIntervalNs]. */
+internal object ScopeTapHzLog {
+    private const val WINDOW_NS = 2_000_000_000L
+    private var windowStartNs = 0L
+    private var taps = 0
+
+    fun note(tag: String, scopes: Int, intervalNs: Long) {
+        val now = System.nanoTime()
+        if (windowStartNs == 0L) windowStartNs = now
+        taps += 1
+        val elapsed = now - windowStartNs
+        if (elapsed < WINDOW_NS) return
+        val hz = taps * 1_000_000_000.0 / elapsed
+        val budget = 1_000_000_000.0 / intervalNs.coerceAtLeast(1)
+        Log.i(
+            tag,
+            "scope tap: ${"%.1f".format(Locale.US, hz)}Hz budget=${"%.0f".format(Locale.US, budget)}Hz scopes=$scopes",
+        )
+        taps = 0
+        windowStartNs = now
+    }
+
+    fun reset() {
+        windowStartNs = 0L
+        taps = 0
     }
 }
 

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/feed/LiveVulkanSession.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/feed/LiveVulkanSession.kt
@@ -1,15 +1,18 @@
 package com.opencapture.openpocketcine.feed
 
+import android.content.Context
 import android.graphics.ImageFormat
 import android.media.Image
 import android.media.ImageReader
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.Looper
+import android.os.PowerManager
 import android.util.Log
 import android.view.Surface
 import com.opencapture.openpocketcine.assists.LiveAssistState
 import com.opencapture.openpocketcine.assists.LiveAssistTool
+import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
@@ -20,13 +23,20 @@ import java.util.concurrent.atomic.AtomicReference
  * the SurfaceView swapchain. No `glReadPixels`, no `TextureView.getBitmap`.
  */
 internal class LiveVulkanSession(
+    context: Context,
     private val onDecoderSurface: (Surface) -> Unit,
     private val onFirstFrame: () -> Unit,
     private val onFailed: () -> Unit,
 ) {
+    private val appContext = context.applicationContext
     private val main = Handler(Looper.getMainLooper())
     private val imageThread = HandlerThread("opc.vk.img").apply { start() }
     private val imageHandler = Handler(imageThread.looper)
+    private val sampleExecutor =
+        Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "opc.vk.scope").apply { isDaemon = true }
+        }
+    private val sampleBusy = AtomicBoolean(false)
     private val handle = if (OpcVulkan.isAvailable) OpcVulkan.nativeCreate() else 0L
     private val slots = FloatArray(GpuLiveLayout.SLOT_STRIDE * 4)
     private val plates = AtomicReference(FloatArray(0))
@@ -40,7 +50,7 @@ internal class LiveVulkanSession(
     private var lastPaint: Any? = cubeSentinel
     private var lastWeight: Any? = cubeSentinel
     @Volatile private var lastPlan: FeedEffectsRenderPlan? = null
-    private var previousBundle = ScopeAssistBundle.EMPTY
+    @Volatile private var previousBundle = ScopeAssistBundle.EMPTY
     private val tapBytes = ByteArray(TAP_W * TAP_H * 4)
     private var lastSampleNs = 0L
     @Volatile var windowReady = false
@@ -231,74 +241,114 @@ internal class LiveVulkanSession(
                 val policy = lastPlan?.scopeTap ?: ScopeTapPolicy.IDLE
                 val wantSample = policy.needsTap
                 val now = System.nanoTime()
-                val due =
-                    wantSample &&
-                        now - lastSampleNs >=
-                            PocketScopeSampler.minIntervalNs(policy.activeScopeCount.coerceAtLeast(1))
-                // 1280→213 blit is per-submit. Arm it only on the 10–15 Hz sample
-                // tick; leaving needTap on made WAVE/PARADE/VECTOR stall every frame.
-                OpcVulkan.nativeSetNeedTap(handle, due)
+                var intervalNs = PocketScopeSampler.BASE_MIN_INTERVAL_NS
+                val takeTap =
+                    if (wantSample && now - lastSampleNs >= PocketScopeSampler.BASE_MIN_INTERVAL_NS) {
+                        val thermal =
+                            runCatching {
+                                val pm =
+                                    appContext.getSystemService(Context.POWER_SERVICE) as PowerManager
+                                PocketScopeSampler.thermalMultiplier(pm.currentThermalStatus)
+                            }.getOrDefault(1.0)
+                        intervalNs =
+                            PocketScopeSampler.minIntervalNs(
+                                policy.activeScopeCount.coerceAtLeast(1),
+                                thermal,
+                            )
+                        now - lastSampleNs >= intervalNs && sampleBusy.compareAndSet(false, true)
+                    } else {
+                        false
+                    }
+                // 1280→213 blit is per-submit. Arm it only on the sample tick;
+                // leaving needTap on made WAVE/PARADE/VECTOR stall every frame.
+                OpcVulkan.nativeSetNeedTap(handle, takeTap)
                 val ok = OpcVulkan.nativeSubmit(handle, hb)
                 hb.close()
                 held?.close()
                 held = image
-                if (ok) {
-                    framesPresented.incrementAndGet()
-                    if (started.compareAndSet(false, true)) main.post(onFirstFrame)
-                    val transfer = MonitorTransfer.fromColorMode(policy.colorMode)
-                    if (!wantSample || !due) {
-                        return@setOnImageAvailableListener
-                    }
-                    lastSampleNs = now
-                    val bundle =
-                        if ((policy.includePoints || policy.includeVectorPoints) &&
-                            OpcVulkan.nativeCopyTap(handle, tapBytes)
-                        ) {
-                            PocketScopeSampler.sample(
-                                bytes = tapBytes,
-                                width = TAP_W,
-                                height = TAP_H,
-                                bytesPerRow = TAP_W * 4,
-                                transfer = transfer,
-                                includePoints = policy.includePoints,
-                                includeVectorPoints = policy.includeVectorPoints,
-                                look = policy.vectorLut,
-                                previous = previousBundle,
-                                iso = policy.iso,
-                            )
-                        } else {
-                            OpcVulkan.nativeCopyHisto(handle, histo)
-                            val y = histo.copyOfRange(0, 256)
-                            val rr = histo.copyOfRange(256, 512)
-                            val gg = histo.copyOfRange(512, 768)
-                            val bb = histo.copyOfRange(768, 1024)
-                            val samples = ScopeSamples(y, rr, gg, bb, emptyList())
-                            ScopeAssistBundle(
-                                revision = previousBundle.revision + 1,
-                                samples = samples,
-                                traffic =
-                                    ScopeTrafficLights.reading(
-                                        red = rr,
-                                        green = gg,
-                                        blue = bb,
-                                        transfer = transfer,
-                                        luma = y,
-                                    ),
-                                histogramDisplay =
-                                    PocketScopeSampler.histogramDisplay(
-                                        samples,
-                                        previousBundle.histogramDisplay,
-                                        transfer,
-                                        policy.iso,
-                                    ),
-                                transfer = transfer,
-                                iso = policy.iso,
-                            )
-                        }
-                    previousBundle = bundle
-                    main.post { LiveScopeSampleBus.publish(bundle) }
-                } else {
+                if (!ok) {
+                    if (takeTap) sampleBusy.set(false)
                     main.post(onFailed)
+                    return@setOnImageAvailableListener
+                }
+                framesPresented.incrementAndGet()
+                if (started.compareAndSet(false, true)) main.post(onFirstFrame)
+                if (!takeTap) return@setOnImageAvailableListener
+                lastSampleNs = now
+                val transfer = MonitorTransfer.fromColorMode(policy.colorMode)
+                val includePoints = policy.includePoints
+                val includeVectorPoints = policy.includeVectorPoints
+                val look = policy.vectorLut
+                val iso = policy.iso
+                val previous = previousBundle
+                val packed =
+                    if ((includePoints || includeVectorPoints) &&
+                        OpcVulkan.nativeCopyTap(handle, tapBytes)
+                    ) {
+                        tapBytes.copyOf()
+                    } else {
+                        null
+                    }
+                val histoCopy =
+                    if (packed == null) {
+                        OpcVulkan.nativeCopyHisto(handle, histo)
+                        histo.copyOf()
+                    } else {
+                        null
+                    }
+                val scopes = policy.activeScopeCount
+                val loggedIntervalNs = intervalNs
+                sampleExecutor.execute {
+                    try {
+                        val bundle =
+                            if (packed != null) {
+                                PocketScopeSampler.sample(
+                                    bytes = packed,
+                                    width = TAP_W,
+                                    height = TAP_H,
+                                    bytesPerRow = TAP_W * 4,
+                                    transfer = transfer,
+                                    includePoints = includePoints,
+                                    includeVectorPoints = includeVectorPoints,
+                                    look = look,
+                                    previous = previous,
+                                    iso = iso,
+                                )
+                            } else {
+                                val bins = histoCopy ?: IntArray(1024)
+                                val y = bins.copyOfRange(0, 256)
+                                val rr = bins.copyOfRange(256, 512)
+                                val gg = bins.copyOfRange(512, 768)
+                                val bb = bins.copyOfRange(768, 1024)
+                                val samples = ScopeSamples(y, rr, gg, bb, emptyList())
+                                ScopeAssistBundle(
+                                    revision = previous.revision + 1,
+                                    samples = samples,
+                                    traffic =
+                                        ScopeTrafficLights.reading(
+                                            red = rr,
+                                            green = gg,
+                                            blue = bb,
+                                            transfer = transfer,
+                                            luma = y,
+                                        ),
+                                    histogramDisplay =
+                                        PocketScopeSampler.histogramDisplay(
+                                            samples,
+                                            previous.histogramDisplay,
+                                            transfer,
+                                            iso,
+                                        ),
+                                    transfer = transfer,
+                                    iso = iso,
+                                )
+                            }
+                        previousBundle = bundle
+                        main.post { LiveScopeSampleBus.publish(bundle) }
+                        ScopeTapHzLog.note(TAG, scopes = scopes, intervalNs = loggedIntervalNs)
+                    } finally {
+                        sampleBusy.set(false)
+                    }
                 }
             },
             imageHandler,

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/feed/PocketScopeSampler.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/feed/PocketScopeSampler.kt
@@ -79,7 +79,7 @@ data class ScopeAssistBundle(
 object PocketScopeSampler {
     const val MAX_WIDTH = 200
     const val POINT_STRIDE = 2
-    const val BASE_MIN_INTERVAL_NS = 1_000_000_000L / 15
+    const val BASE_MIN_INTERVAL_NS = 1_000_000_000L / 25
     const val DENSE_MIN_INTERVAL_NS = 1_000_000_000L / 10
     const val DENSE_ASSIST_THRESHOLD = 2
     const val TRAIL_DECAY = 0.35

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openpocketcine/feed/PocketScopeSamplerTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openpocketcine/feed/PocketScopeSamplerTest.kt
@@ -18,11 +18,37 @@ class PocketScopeSamplerTest {
         assertEquals(120, h)
         assertEquals(PocketScopeSampler.MAX_WIDTH, 200)
         assertEquals(PocketScopeSampler.POINT_STRIDE, 2)
-        assertEquals(1_000_000_000L / 15, PocketScopeSampler.BASE_MIN_INTERVAL_NS)
+        assertEquals(1_000_000_000L / 25, PocketScopeSampler.BASE_MIN_INTERVAL_NS)
         assertEquals(1_000_000_000L / 10, PocketScopeSampler.DENSE_MIN_INTERVAL_NS)
+        assertEquals(PocketScopeSampler.BASE_MIN_INTERVAL_NS, PocketScopeSampler.minIntervalNs(1))
+        assertEquals(PocketScopeSampler.BASE_MIN_INTERVAL_NS, PocketScopeSampler.minIntervalNs(2))
+        assertEquals(PocketScopeSampler.DENSE_MIN_INTERVAL_NS, PocketScopeSampler.minIntervalNs(3))
         assertTrue(PocketScopeSampler.minIntervalNs(1) < PocketScopeSampler.minIntervalNs(3))
         assertEquals(3.0, PocketScopeSampler.thermalMultiplier(3))
         assertEquals(5.0, PocketScopeSampler.thermalMultiplier(4))
+        assertEquals(
+            3 * PocketScopeSampler.BASE_MIN_INTERVAL_NS,
+            PocketScopeSampler.minIntervalNs(1, 3.0),
+        )
+        // 15 Hz next to a 25 fps well is a 2-frame hold. WAVE-only must
+        // tap every typical SoftAP picture; dense 3+ stays the 10 Hz back-off.
+        assertEquals(25, scheduledTaps(frames = 25, fps = 25, PocketScopeSampler.minIntervalNs(1)))
+        // 10 Hz on a 40 ms picture clock lands every third frame (deadline skip).
+        assertEquals(9, scheduledTaps(frames = 25, fps = 25, PocketScopeSampler.minIntervalNs(3)))
+    }
+
+    private fun scheduledTaps(frames: Int, fps: Int, intervalNs: Long): Int {
+        var next = 0L
+        var taps = 0
+        val dt = 1_000_000_000L / fps
+        for (i in 0 until frames) {
+            val now = i * dt
+            if (now >= next) {
+                next = now + intervalNs
+                taps += 1
+            }
+        }
+        return taps
     }
 
     @Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -313,6 +313,11 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- Live WAVE / PARADE / HISTO / VECTOR tracked the picture at 15 Hz (10 Hz
+  with three or more), so traces held about two SoftAP frames. Nominal tap
+  is 25 Hz with 1–2 scopes; dense 3+ stays 10 Hz; thermal still ×3 / ×5.
+  Downsample is 200-wide (213×120 on 720p). Android Vulkan walks the tap
+  off the image thread so 25 Hz cannot stall the well.
 - Disconnected library Auto LUT keeps the clip's D-Log / D-Log2 cube. Opening
   the LUT sheet no longer restamps Auto from a missing live SET (that showed
   “No matching look for this color / camera” on a log clip). Color is

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -18,7 +18,7 @@ the same PR.
 | Live enable | **Enable-once.** Further enables follow the watchdog only | `AGENTS.md`, [`feed-watchdog.md`](feed-watchdog.md) |
 | Stall / recover | 2 s UDP silence is a stall; 8 s GOP grace after `0x09/0xa8`; 4 s after an AF-C SET; 5 s between enables; 60 s UDP rebuild backoff | `FeedWatchdog`, [`feed-watchdog.md`](feed-watchdog.md) |
 | HUD chrome | 5 Hz (`LiveChromeThrottle.statusInterval` = 0.2 s). REC, format, color, zoom, and the other `isImmediate` fields bypass | `LiveChromeThrottle` |
-| Scope tap | 10–15 Hz on a 213×120 downsample. Not every HEVC frame. Assists-off is one blit — no 1280×720 histogram or readback per frame | [`ANDROID.md`](../ANDROID.md) I/O; iOS present path matches the rate |
+| Scope tap | 25 Hz with 1–2 scopes, 10 Hz with 3+ (`PocketScopeSampler`). 200-wide downsample (213×120 on 720p SoftAP). Thermal ×3 serious / ×5 critical. A 50 Hz proxy still skips. Assists-off is one blit — no 1280×720 histogram or readback per frame | [`ANDROID.md`](../ANDROID.md) I/O; iOS present path matches the rate |
 | HUD glass sample | PixelCopy ~20 Hz when Kyant cannot sample the SurfaceView | [`ANDROID.md`](../ANDROID.md) |
 | Zoom pinch | Distinct lens ticks at 20 Hz, no ACK wait | [`PARITY.md`](PARITY.md) |
 | Battery | Sticky `ACTION_BATTERY_CHANGED` (Android); no 1 Hz poll | [`ANDROID.md`](../ANDROID.md) |

--- a/ios/OpenPocketCine/LiveFrameSample.swift
+++ b/ios/OpenPocketCine/LiveFrameSample.swift
@@ -97,8 +97,9 @@ enum PocketScopeSampler {
     /// Known-good OpenZCine width. 128 + extra pack/vImage was slower on device.
     static let maxWidth = 200
     static let pointStride = 2
-    /// SoftAP stays 25 fps. Scopes do not ride every AU — a hard deadline skips.
-    static let baseMinInterval: CFAbsoluteTime = 1.0 / 15.0
+    /// Typical SoftAP is 25 fps. 1–2 scopes track that picture; a 50 Hz
+    /// proxy still skips. Deadline cannot catch up.
+    static let baseMinInterval: CFAbsoluteTime = 1.0 / 25.0
     /// More scopes share one tap — go slower, not faster.
     static let denseMinInterval: CFAbsoluteTime = 1.0 / 10.0
     static let denseAssistThreshold = 2
@@ -311,7 +312,7 @@ final class LiveFrameSampleBus {
     @ObservationIgnored var sourcePixelBuffer: CVPixelBuffer?
     var transfer: MonitorTransfer = .rec709
     var colorMode: ColorMode?
-    /// Bumps when a new scope bundle lands (≤15 Hz). Present is not gated on this.
+    /// Bumps when a new scope bundle lands (≤25 Hz). Present is not gated on this.
     private(set) var generation = 0
     /// Incremented for every decoded pixel buffer that enters the assist pipeline.
     /// Tests use this to prove the callback ran without hardware HEVC.
@@ -388,7 +389,9 @@ final class LiveAssistEngine: @unchecked Sendable {
     private var nextCeilingLogAt: CFAbsoluteTime = 0
     private var previousBundle = ScopeAssistBundle.empty
     private var loggedTap = false
-    /// Shared tap: 15 Hz, 10 Hz with three or more scopes, shed further by
+    private var tapWindowStart: CFAbsoluteTime = 0
+    private var tapsInWindow = 0
+    /// Shared tap: 25 Hz, 10 Hz with three or more scopes, shed further by
     /// thermal tier (×3 serious, ×5 critical). Deadline cannot catch up.
 
     init() {}
@@ -433,6 +436,8 @@ final class LiveAssistEngine: @unchecked Sendable {
             nextScopeAt = 0
             previousBundle = .empty
             loggedTap = false
+            tapWindowStart = 0
+            tapsInWindow = 0
             ceilingLogMax = 0
             nextCeilingLogAt = 0
             ScopeExposureCeiling.reset()
@@ -565,6 +570,21 @@ final class LiveAssistEngine: @unchecked Sendable {
             previousBundle = sampled
             let observed = ScopeExposureCeiling.observeTapMax(tapMax, transfer: transfer)
             logTapOnce(buffer: buffer, packed: packed, points: sampled.samples.points.count)
+            let tapNow = CFAbsoluteTimeGetCurrent()
+            let interval = PocketScopeSampler.minInterval(activeScopeCount: fx.activeScopeCount)
+            tapsInWindow += 1
+            if tapWindowStart == 0 { tapWindowStart = tapNow }
+            let elapsed = tapNow - tapWindowStart
+            if elapsed >= 2 {
+                let hz = Double(tapsInWindow) / elapsed
+                let budget = 1.0 / interval
+                ControlLiveLog.line(
+                    String(
+                        format: "scope tap: %.1fHz budget=%.0fHz scopes=%d", hz, budget,
+                        fx.activeScopeCount))
+                tapsInWindow = 0
+                tapWindowStart = tapNow
+            }
             // Ceiling calibration breadcrumb: rolling 10 s tap maximum
             // into the pullable journal (tools/pull-control-log.sh).
             // Point the lens at a blown lamp at each ISO and read the

--- a/ios/OpenPocketCine/LiveViewScreen.swift
+++ b/ios/OpenPocketCine/LiveViewScreen.swift
@@ -923,7 +923,7 @@ private struct LiveRecordingTallyGate: View {
     }
 }
 
-/// Scope panels observe `frameSamples.bundle` themselves (≤15 Hz). This host
+/// Scope panels observe `frameSamples.bundle` themselves (≤25 Hz). This host
 /// only tracks assist on/off flags — not `generation`.
 private struct LiveScopeOverlays: View {
     @Environment(AppModel.self) private var model

--- a/ios/OpenPocketCine/ScopeTraceMetalView.swift
+++ b/ios/OpenPocketCine/ScopeTraceMetalView.swift
@@ -218,7 +218,7 @@ final class ScopeTraceRenderer: NSObject, MTKViewDelegate {
     /// straight into a slot's `contents()`; `draw(in:)` only binds the
     /// published buffer. Depth 3 means a slot is not rewritten until two newer
     /// builds — each with its draw scheduled immediately on publish — landed.
-    /// ponytail: no semaphore; builds are ≤15 Hz and draws complete within a
+    /// ponytail: no semaphore; builds are ≤25 Hz and draws complete within a
     /// frame. Add completion-handler slot tracking if draw cadence ever
     /// decouples from builds.
     private final class VertexRing: @unchecked Sendable {

--- a/ios/OpenPocketCineTests/LiveFrameSampleTests.swift
+++ b/ios/OpenPocketCineTests/LiveFrameSampleTests.swift
@@ -67,8 +67,8 @@ final class LiveFrameSampleTests: XCTestCase {
         let first = bus.generation
         XCTAssertGreaterThanOrEqual(first, 1, "first scoped sample must tick generation")
 
-        // Past the 15 Hz gate.
-        try? await Task.sleep(for: .milliseconds(100))
+        // Past the 25 Hz gate.
+        try? await Task.sleep(for: .milliseconds(50))
         decoder.handleDecodedFrame(
             ScopeTestBuffers.makeFlatBuffer(code: 200), effects: fx, transfer: .rec709)
         let secondDeadline = Date().addingTimeInterval(2)
@@ -78,7 +78,7 @@ final class LiveFrameSampleTests: XCTestCase {
         }
 
         XCTAssertGreaterThan(
-            bus.generation, first, "each scoped sample past the 15 Hz gate must tick generation")
+            bus.generation, first, "each scoped sample past the 25 Hz gate must tick generation")
         XCTAssertGreaterThanOrEqual(bus.decodedFrames, 2, "sequential feed drains every frame")
     }
 
@@ -378,8 +378,8 @@ final class LiveFrameSampleTests: XCTestCase {
 
     // MARK: - Throttle constants
 
-    func testScopeTapIntervalIsAtMost15Hz() {
-        XCTAssertEqual(PocketScopeSampler.baseMinInterval, 1.0 / 15.0, accuracy: 1e-9)
+    func testScopeTapIntervalTracksTypicalSoftAPRate() {
+        XCTAssertEqual(PocketScopeSampler.baseMinInterval, 1.0 / 25.0, accuracy: 1e-9)
         XCTAssertEqual(PocketScopeSampler.denseMinInterval, 1.0 / 10.0, accuracy: 1e-9)
         XCTAssertEqual(
             PocketScopeSampler.minInterval(activeScopeCount: 1, thermalState: .nominal),
@@ -397,9 +397,32 @@ final class LiveFrameSampleTests: XCTestCase {
         XCTAssertEqual(PocketScopeSampler.thermalMultiplier(.critical), 5)
         XCTAssertEqual(
             PocketScopeSampler.minInterval(activeScopeCount: 1, thermalState: .serious),
-            3.0 / 15.0, accuracy: 1e-9)
+            3.0 / 25.0, accuracy: 1e-9)
         XCTAssertEqual(PocketScopeSampler.maxWidth, 200)
         XCTAssertEqual(PocketScopeSampler.pointStride, 2)
+        // 15 Hz next to a 25 fps well is a 2-frame hold. WAVE-only must
+        // tap every typical SoftAP picture; dense 3+ stays the 10 Hz back-off.
+        XCTAssertEqual(
+            scheduledScopeTaps(frames: 25, fps: 25, interval: PocketScopeSampler.baseMinInterval),
+            25)
+        // 10 Hz on a 40 ms picture clock lands every third frame (deadline skip).
+        XCTAssertEqual(
+            scheduledScopeTaps(frames: 25, fps: 25, interval: PocketScopeSampler.denseMinInterval),
+            9)
+    }
+
+    private func scheduledScopeTaps(frames: Int, fps: Double, interval: CFAbsoluteTime) -> Int {
+        var next = 0.0
+        var taps = 0
+        let dt = 1.0 / fps
+        for i in 0..<frames {
+            let now = Double(i) * dt
+            if now + 1e-12 >= next {
+                next = now + interval
+                taps += 1
+            }
+        }
+        return taps
     }
 
     // MARK: - Sampler contracts (app layer)

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -13,8 +13,8 @@ Fixes
 - Traffic Lights crush/clip compensation starts at 0 stops. Long-press LIGHTS if you want the old ¼-stop tolerance.
 - First connect no longer sits on Waiting for live-view when a few video packets arrive and then freeze.
 - After leaving a clip, a dead picture with live camera status rebuilds the socket in about two seconds instead of sitting black for 15.
-- The live feed comes up as soon as the camera answers, instead of waiting out extra beats.
-- If the camera is still talking but the picture dies, the app asks for a fresh frame instead of sitting on a black well.
+- The live feed comes up as soon as the camera answers. If the picture dies while the camera is still talking, the app asks for a fresh frame instead of sitting black.
+- Live WAVE follows the picture instead of stepping every other frame. PARADE / HISTO / VECTOR share that tap.
 - Gimbal stick and zoom chip stay together (zoom above the stick) in the trailing-bottom of the picture on iPhone and iPad, portrait and landscape — not glued to the record button. On iPad landscape they sit on the right edge above the record button.
 - On iPad the system time / battery bar should be gone. HUD chips (STBY, TC, battery) stay.
 
@@ -24,4 +24,4 @@ What to test
 - Share that clip with Bake LUT on. Bake exposure should be on by default — a −1.0 pull should land in the file, matching the monitor. Turn Bake exposure off to keep the cube at 0.0. Share without Bake LUT still sends the original camera clip, not a small preview.
 - Leave the clip and confirm live view returns in a couple of seconds — not a long black well.
 - Set MODE to Auto, open EV, turn Face Priority on, then off — EV should return to the value from before it was on (or 0.0).
-- In Manual, open SHUTTER, switch to Angle, pick 180°, and confirm the tile shows 180°.
+- On live, turn WAVE on and pan the Pocket. Traces should move with the picture, not hold two frames. The well itself should stay smooth. Then add PARADE. In Manual, SHUTTER Angle 180° should still show 180° on the tile.


### PR DESCRIPTION
## What & why

Closes #130.

WAVE / PARADE / HISTO / VECTOR tapped at 15 Hz (10 Hz with three or more) next to a ~25 fps SoftAP well, so traces held about two picture frames even when the feed was fine. Overlays already observe the scope bundle, not the 5 Hz HUD.

Nominal tap is **25 Hz** with 1–2 scopes so WAVE tracks a typical Pocket picture 1:1. Dense 3+ stays **10 Hz**. Thermal is still ×3 / ×5. Docs now say 200-wide (213×120 on 720p), matching `maxWidth = 200`.

Android Vulkan walks the tap off the image thread (and applies thermal) so 25 Hz cannot stall the well. A 2 s `scope tap: …Hz budget=…Hz` breadcrumb is in `control-live.log` / logcat.

## TestFlight notes

Updated `ios/TestFlight/WhatToTest.en-US.txt`: live WAVE follows the picture; testers pan a Pocket with WAVE on, then add PARADE.

## Checklist

- [x] `just check` passes.
- [x] Native: iOS `LiveFrameSampleTests` (interval + generation) and Android `PocketScopeSamplerTest` / `GpuLiveLayoutTest` pass. `just check` is the repo gate; full `just native-check` / `just android-check` run in CI.
- [x] Commits follow Conventional Commits.
- [x] No captures, Wi-Fi passwords, unofficial LUT dumps, signing material, or other secrets.
- [x] Docs/CHANGELOG updated (`docs/PERFORMANCE.md`, `ANDROID.md`, `CHANGELOG.md`). Handbook not duplicated — live-path Hz lives in PERFORMANCE.md.
- [x] TestFlight-triggering changes include reviewed `ios/TestFlight/WhatToTest.en-US.txt` copy.
- [ ] iOS release PRs: not a version-train bump.

## Physical

WAVE on a moving Pocket take, iPhone 16 Pro Max (`es_iphone16`). Traces track the picture; well stays at the camera live rate. Android not attached this session.