### PR TITLE
fix: inflate the Android splash icon on API 29/30

### DIFF
--- a/Apps/Android/Play/WhatToTest.en-US.txt
+++ b/Apps/Android/Play/WhatToTest.en-US.txt
@@ -6,10 +6,11 @@ New and changed
 
 Fixes
 
-- Live view should come up in a couple of seconds after Wi-Fi joins, not sit on Waiting for live view. White balance Auto keeps tint. Zoom chips match the body (4 Pro 1×/3×/6×/12×, Pocket 4 1×/2×/4×). Zoom must keep the live picture, not just HUD and stick. FORMAT only lists what this camera can do. COLOR lists what this camera has: D-Log2 only on Pocket 4 Pro; Pocket 3 is D-Log M, not D-Log / D-Log2.
+- On some Android 10 phones and tablets the app closed before the OpenPocketCine wordmark. Cold start should now reach the wordmark on a dark screen, still with no square logo flash.
+- Live view should come up in a couple of seconds after Wi-Fi joins, not sit on Waiting for live view. White balance Auto keeps tint. Zoom chips match the body (4 Pro 1×/3×/6×/12×, Pocket 4 1×/2×/4×). Zoom must keep the live picture, not just HUD and stick.
 
 What to test
 
-- Pair an Osmo Pocket 4 Pro, join its Wi-Fi, and confirm live view fills the monitor in a couple of seconds. Cycle zoom 1×→3×→6×→12× — the picture must stay. COLOR should include D-Log2. On Pocket 3, COLOR is Normal / HDR / D-Log M — not D-Log2.
+- Cold-start on an Android 10 device, or any 64-bit phone on Android 10 or newer. Confirm it opens to the wordmark, not a crash, and that the first screen is the dark hold with no square icon in the middle.
+- Pair an Osmo Pocket 4 Pro, join its Wi-Fi, and confirm live view fills the monitor in a couple of seconds.
 - Record a short take, then open it in the library with LUT on. Share should send the original file, not a small preview.
-- Confirm the app installs on a 64-bit phone running Android 10 or newer.

--- a/Apps/Android/Play/whatsnew/whatsnew-en-US
+++ b/Apps/Android/Play/whatsnew/whatsnew-en-US
@@ -1,1 +1,1 @@
-First closed beta. Pair an Osmo Pocket over Bluetooth, join its Wi-Fi, and watch live view with waveform and assists. Record, ISO, zoom, and gimbal from the phone. COLOR matches the body (D-Log2 only on Pocket 4 Pro). Open clips from the camera — Share and Save use the original file. Needs a 64-bit phone, Android 10 or newer.
+Cold start on Android 10 should reach the OpenPocketCine wordmark instead of closing before the first screen. Still no square logo flash. Pair, live view, record, and library share are unchanged.

--- a/Apps/Android/app/src/main/res/drawable/opc_splash_empty.xml
+++ b/Apps/Android/app/src/main/res/drawable/opc_splash_empty.xml
@@ -4,5 +4,11 @@
     android:height="288dp"
     android:viewportWidth="288"
     android:viewportHeight="288">
-    <!-- Transparent hold so AndroidX SplashScreen never flashes a square logo. -->
+    <!-- Transparent hold so AndroidX SplashScreen never flashes a square logo.
+         The path is required, not decorative: API 29/30 inflate this icon through
+         VectorDrawable, which rejects a vector with no path ("no path defined").
+         API 31+ draws the splash in the platform and never inflates it. -->
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M0,0h288v288h-288z" />
 </vector>


### PR DESCRIPTION
`installSplashScreen()` threw `Resources$NotFoundException` before the first frame on every minSdk device: `opc_splash_empty` was a `<vector>` carrying only a comment, and `VectorDrawable.inflateChildElements` rejects a vector with no `<path>` ("no path defined"). API 31+ draws the splash in the platform and never inflates the icon, so the crash was invisible above API 30 and to lint and unit tests.

Give the vector one fully transparent path. The hold stays invisible, so the splash still never flashes a square logo.

Crash reproduced on a physical MI_PAD_4 (Android 10, API 29, arm64-v8a).

App works fine on Pixel 10. 


## What & why

<!-- What does this PR change, and why? Link any related issue. -->

## TestFlight notes

<!--
If this PR changes Sources/, Tests/, ios/, Package.swift, scripts/, or justfile, replace
ios/TestFlight/WhatToTest.en-US.txt:
- New and changed (1-6 bullets)
- Fixes (1-8 bullets)
- What to test (1-5 concrete actions)
Write for camera operators. For a build with no tester-facing app behavior, say that plainly.
-->

## Checklist

- [ ] `just check` passes.
- [ ] Native production changes: `just native-check` passes, or the relevant platform check is noted.
- [ ] Commits follow Conventional Commits.
- [ ] No captures, Wi-Fi passwords, unofficial LUT dumps, signing material, or other secrets.
- [ ] Docs/CHANGELOG updated if behavior or setup changed. Public handbook pages updated when protocol, app, or setup visitors read has changed.
- [ ] TestFlight-triggering changes include reviewed `ios/TestFlight/WhatToTest.en-US.txt` copy.
- [ ] iOS release PRs: bump `MARKETING_VERSION` in `ios/Config/Version.xcconfig` when starting a new version train.
