### PR TITLE
fix: keep the Android system bars up outside the monitor

### DIFF
--- a/Apps/Android/Play/WhatToTest.en-US.txt
+++ b/Apps/Android/Play/WhatToTest.en-US.txt
@@ -6,11 +6,11 @@ New and changed
 
 Fixes
 
-- On some Android 10 phones and tablets the app closed before the OpenPocketCine wordmark. Cold start should now reach the wordmark on a dark screen, still with no square logo flash.
-- Live view should come up in a couple of seconds after Wi-Fi joins, not sit on Waiting for live view. White balance Auto keeps tint. Zoom chips match the body (4 Pro 1×/3×/6×/12×, Pocket 4 1×/2×/4×). Zoom must keep the live picture, not just HUD and stick.
+- Pairing and Operator Setup no longer sit under the clock. Opening Settings or the library from live view brings the status bar back so the header is readable. Live view still hides the bars until you swipe in from the edge.
+- Live view should come up in a couple of seconds after Wi-Fi joins, not sit on Waiting for live view. White balance Auto keeps tint. Zoom chips match the body.
 
 What to test
 
-- Cold-start on an Android 10 device, or any 64-bit phone on Android 10 or newer. Confirm it opens to the wordmark, not a crash, and that the first screen is the dark hold with no square icon in the middle.
-- Pair an Osmo Pocket 4 Pro, join its Wi-Fi, and confirm live view fills the monitor in a couple of seconds.
+- Cold start: the pairing title should sit below the time.
+- Connect, then open Settings and the library from the live monitor. Headers should clear the status bar. Back on live view the bars should hide again; a swipe from the edge should show them briefly.
 - Record a short take, then open it in the library with LUT on. Share should send the original file, not a small preview.

--- a/Apps/Android/Play/whatsnew/whatsnew-en-US
+++ b/Apps/Android/Play/whatsnew/whatsnew-en-US
@@ -1,1 +1,1 @@
-Cold start on Android 10 should reach the OpenPocketCine wordmark instead of closing before the first screen. Still no square logo flash. Pair, live view, record, and library share are unchanged.
+Pairing and Operator Setup no longer sit under the clock. Opening Settings or the library from live view brings the status bar back so headers stay readable. Live view still hides the bars until you swipe in from the edge.

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/ImmersiveSystemBars.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/ImmersiveSystemBars.kt
@@ -46,9 +46,17 @@ fun applyImmersiveSystemBars(window: Window) {
  * OpenZCine sticky-immersive cycle: observe an inward swipe from a screen
  * edge, `show()` the bars so real insets land, hold, then `hide()`.
  * Pointer events are not consumed — chrome and pairing still get the tap.
+ *
+ * Only the live monitor runs immersive. With [enabled] false the bars are the
+ * platform's to draw, so the cycle stands down entirely — otherwise a stray
+ * edge swipe on setup would `hide()` them and take the status-bar inset with it.
  */
 @Composable
-fun ImmersiveSystemBarCycle(content: @Composable () -> Unit) {
+fun ImmersiveSystemBarCycle(enabled: Boolean = true, content: @Composable () -> Unit) {
+    if (!enabled) {
+        CompositionLocalProvider(LocalImmersiveBarInsets provides Insets.NONE) { content() }
+        return
+    }
     var barsShown by remember { mutableStateOf(false) }
     var barInsets by remember { mutableStateOf(Insets.NONE) }
     val view = LocalView.current
@@ -118,5 +126,13 @@ fun ImmersiveSystemBarCycle(content: @Composable () -> Unit) {
         ) {
             content()
         }
+    }
+}
+
+/** Restores the system bars. Setup and pairing chrome needs a real status-bar inset. */
+fun showSystemBars(window: Window) {
+    WindowCompat.getInsetsController(window, window.decorView).apply {
+        systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
+        show(WindowInsetsCompat.Type.systemBars())
     }
 }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/MainActivity.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/MainActivity.kt
@@ -26,6 +26,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -66,6 +69,13 @@ class MainActivity : ComponentActivity() {
     private val composeFirstFrameDrawn = AtomicBoolean(false)
     private lateinit var model: AppModel
 
+    /**
+     * Only the live monitor hides the system bars. Setup and pairing keep them so
+     * their chrome gets a real status-bar inset instead of drawing under the clock.
+     * [onWindowFocusChanged] reasserts whichever mode the current screen asked for.
+     */
+    @Volatile var wantsImmersive = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
         splashScreen.setKeepOnScreenCondition { !composeFirstFrameDrawn.get() }
@@ -78,7 +88,6 @@ class MainActivity : ComponentActivity() {
         window.isNavigationBarContrastEnforced = false
         window.attributes.layoutInDisplayCutoutMode =
             WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
-        applyImmersiveSystemBars(window)
         setContent {
             SideEffect { composeFirstFrameDrawn.set(true) }
             OpenPocketCineTheme {
@@ -92,7 +101,8 @@ class MainActivity : ComponentActivity() {
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
-        if (hasFocus) applyImmersiveSystemBars(window)
+        if (!hasFocus) return
+        if (wantsImmersive) applyImmersiveSystemBars(window) else showSystemBars(window)
     }
 
     override fun onPause() {
@@ -158,13 +168,20 @@ private fun OpenPocketCineApp(model: AppModel) {
         model.showsLaunchSplash = false
     }
 
-    LaunchedEffect(activity) {
+    val showLive = phase == ConnectionPhase.LIVE || model.session.holdsMonitor
+    // Only the monitor itself runs immersive. Media library and settings open as
+    // full-screen panels *over* live, and they are ordinary chrome: their
+    // statusBarsPadding() measures zero while the bars are hidden, so the header
+    // rides under the clock. Bring the bars back for as long as a panel is up.
+    val immersive = showLive && model.liveOperatorPanel == null
+
+    LaunchedEffect(activity, immersive) {
         val window = activity?.window ?: return@LaunchedEffect
-        applyImmersiveSystemBars(window)
+        (activity as? MainActivity)?.wantsImmersive = immersive
+        if (immersive) applyImmersiveSystemBars(window) else showSystemBars(window)
     }
 
-    val showLive = phase == ConnectionPhase.LIVE || model.session.holdsMonitor
-    ImmersiveSystemBarCycle {
+    ImmersiveSystemBarCycle(enabled = immersive) {
     Box(Modifier.fillMaxSize().startupBackdrop()) {
         if (showLive) {
             LiveViewScreen(model)
@@ -221,6 +238,10 @@ private fun LinkExperience(
     Column(
         Modifier
             .fillMaxSize()
+            // Two insets, and they never both apply. Setup keeps the bars up, so safeDrawing
+            // carries the real status-bar height; the monitor hides them, so safeDrawing is
+            // empty there and the transient swipe-reveal lanes below do the work instead.
+            .windowInsetsPadding(WindowInsets.safeDrawing)
             .padding(start = barStart, top = 16.dp + barTop, end = barEnd, bottom = 16.dp + barBottom),
     ) {
         Box(Modifier.padding(horizontal = 20.dp)) {


### PR DESCRIPTION
Fix status bar not showing up in certain screens. App content would appear behind status bar otherwise.

After fix:

<img width="1080" height="2424" alt="Screenshot_20260829-225325" src="https://github.com/user-attachments/assets/38313043-dee5-418e-8452-e0749c071434" />

<img width="1080" height="2424" alt="Screenshot_20260829-225124" src="https://github.com/user-attachments/assets/544dd4a4-4847-4478-86d7-d6f1336a9e4f" />

## What & why

<!-- What does this PR change, and why? Link any related issue. -->

## TestFlight notes

<!--
If this PR changes Sources/, Tests/, ios/, Package.swift, scripts/, or justfile, replace
ios/TestFlight/WhatToTest.en-US.txt:
- New and changed (1-6 bullets)
- Fixes (1-8 bullets)
- What to test (1-5 concrete actions)
Write for camera operators. For a build with no tester-facing app behavior, say that plainly.
-->

## Checklist

- [ ] `just check` passes.
- [ ] Native production changes: `just native-check` passes, or the relevant platform check is noted.
- [ ] Commits follow Conventional Commits.
- [ ] No captures, Wi-Fi passwords, unofficial LUT dumps, signing material, or other secrets.
- [ ] Docs/CHANGELOG updated if behavior or setup changed. Public handbook pages updated when protocol, app, or setup visitors read has changed.
- [ ] TestFlight-triggering changes include reviewed `ios/TestFlight/WhatToTest.en-US.txt` copy.
- [ ] iOS release PRs: bump `MARKETING_VERSION` in `ios/Config/Version.xcconfig` when starting a new version train.