### PR TITLE
fix: stop rebuilding the Android decoder on every keyframe

### DIFF
--- a/Apps/Android/Play/WhatToTest.en-US.txt
+++ b/Apps/Android/Play/WhatToTest.en-US.txt
@@ -6,11 +6,11 @@ New and changed
 
 Fixes
 
-- Pairing and Operator Setup no longer sit under the clock. Opening Settings or the library from live view brings the status bar back so the header is readable. Live view still hides the bars until you swipe in from the edge.
-- Live view should come up in a couple of seconds after Wi-Fi joins, not sit on Waiting for live view. White balance Auto keeps tint. Zoom chips match the body.
+- On a Nano, live view no longer rebuilds once a second. The picture should stay up, not hitch or go black while the camera is still talking.
+- Live view should come up in a couple of seconds after Wi-Fi joins, not sit on Waiting for live view. Zoom must keep the live picture, not just HUD and stick.
 
 What to test
 
-- Cold start: the pairing title should sit below the time.
-- Connect, then open Settings and the library from the live monitor. Headers should clear the status bar. Back on live view the bars should hide again; a swipe from the edge should show them briefly.
+- Pair an Osmo Nano, join its Wi-Fi, and leave live view running for about a minute. The picture must stay; it should not blink or rebuild every second.
+- Pair a Pocket 4 / 4 Pro and confirm live view still fills. Cycle zoom; the picture must stay.
 - Record a short take, then open it in the library with LUT on. Share should send the original file, not a small preview.

--- a/Apps/Android/Play/whatsnew/whatsnew-en-US
+++ b/Apps/Android/Play/whatsnew/whatsnew-en-US
@@ -1,1 +1,1 @@
-Pairing and Operator Setup no longer sit under the clock. Opening Settings or the library from live view brings the status bar back so headers stay readable. Live view still hides the bars until you swipe in from the edge.
+On a Nano, live view should stay up instead of hitching or going black about once a second. Pair, zoom, record, and library share are unchanged on Pocket bodies.

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/session/HevcDecoder.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/session/HevcDecoder.kt
@@ -154,12 +154,19 @@ class HevcDecoder {
         val idr = isIdrPicture(types, accessUnit)
         val csd = SwiftCore.hevcCsd(accessUnit)
         var sizeCallback: Pair<Int, Int>? = null
-        if (csd != null && detectCodec(csd, types) != null) {
+        // `hevcCsd` hands back a blob for every access unit, not only parameter-set-bearing ones:
+        // a 16 KB P-frame comes back carrying no VPS/SPS/PPS at all. Taking that as the new
+        // baseline made the comparison alternate 30 bytes <-> 0 bytes and report a change on
+        // every access unit, so a Nano rebuilt its decoder once a second, on every IDR, to the
+        // same 1280x720. An access unit with no parameter sets cannot signal a parameter-set
+        // change, and must not become the baseline the next keyframe is compared against.
+        val nextSets = csd?.let { parameterSetNals(it) } ?: ByteArray(0)
+        if (csd != null && nextSets.isNotEmpty() && detectCodec(csd, types) != null) {
             val changing =
                 EncoderPresentPath.parameterSetsChanged(
                     hadFormat = configured || builtCsd != null,
-                    previousCsd = builtCsd,
-                    nextCsd = csd,
+                    previousCsd = builtCsd?.let { parameterSetNals(it) },
+                    nextCsd = nextSets,
                 )
             pendingCsd = csd
             pendingTypes = types
@@ -557,6 +564,38 @@ class HevcDecoder {
             } else {
                 3
             }
+
+        /**
+         * The parameter-set NALs in [csd], start codes kept, in wire order.
+         *
+         * Only VPS/SPS/PPS decide whether MediaCodec has to be reconfigured, so only those may
+         * count as a parameter-set change. Comparing whole CSD blobs makes anything else riding
+         * along — an SEI whose payload varies per keyframe, a differing NAL order — look like a
+         * format change: a Nano rebuilt the decoder once a second, on every IDR, to the same
+         * 1280x720. This matches OpenPocketViewCore `EncoderPresentPath.parameterSetsChanged`,
+         * which already compares VPS/SPS/PPS separately.
+         *
+         * HEVC VPS/SPS/PPS lead with 0x40/0x42/0x44; AVC SPS/PPS with 0x67/0x68 — the same bytes
+         * [detectCodec] keys on.
+         */
+        internal fun parameterSetNals(csd: ByteArray): ByteArray {
+            val sets = ArrayList<ByteArray>()
+            for (nal in annexBNals(csd)) {
+                val skip = startCodeLength(nal)
+                if (nal.size <= skip) continue
+                when (nal[skip].toInt() and 0xFF) {
+                    0x40, 0x42, 0x44, 0x67, 0x68 -> sets.add(nal)
+                }
+            }
+            if (sets.isEmpty()) return ByteArray(0)
+            val merged = ByteArray(sets.sumOf { it.size })
+            var at = 0
+            for (nal in sets) {
+                nal.copyInto(merged, at)
+                at += nal.size
+            }
+            return merged
+        }
 
         private fun nalTypeAfterStartCode(nal: ByteArray): Int {
             val skip = startCodeLength(nal)

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openpocketcine/session/HevcParameterSetNalsTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openpocketcine/session/HevcParameterSetNalsTest.kt
@@ -1,0 +1,80 @@
+package com.opencapture.openpocketcine.session
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * `SwiftCore.hevcCsd` returns a blob for every access unit, not only parameter-set-bearing ones:
+ * on a Nano a keyframe yields 31 bytes of SPS+PPS and the next P-frame yields 16 KB carrying no
+ * parameter sets at all. Comparing whole blobs alternated between the two and reported a change
+ * on every access unit, so the decoder was rebuilt once a second to the same 1280x720.
+ *
+ * [HevcDecoder.parameterSetNals] is what lets the caller tell the two apart.
+ */
+class HevcParameterSetNalsTest {
+    private val startCode = byteArrayOf(0, 0, 0, 1)
+
+    private fun nal(lead: Int, vararg body: Int): ByteArray =
+        startCode + byteArrayOf(lead.toByte()) + body.map { it.toByte() }.toByteArray()
+
+    // Compare extraction against extraction, never against the raw input: annexBNals splits on
+    // the 3-byte start code, so the first NAL of a blob written with 4-byte start codes comes
+    // back one leading zero shorter. That is deterministic, which is all a comparison needs.
+    @Test
+    fun keepsAvcSpsAndPpsAndDropsEverythingElse() {
+        val sps = nal(0x67, 0x42, 0x00)
+        val pps = nal(0x68, 0xCE)
+        val sei = nal(0x06, 0x05, 0x11)
+        val aud = nal(0x09, 0x10)
+        assertContentEquals(
+            HevcDecoder.parameterSetNals(sps + pps),
+            HevcDecoder.parameterSetNals(aud + sei + sps + pps),
+        )
+    }
+
+    @Test
+    fun keepsHevcVpsSpsPps() {
+        val vps = nal(0x40, 0x01)
+        val sps = nal(0x42, 0x01)
+        val pps = nal(0x44, 0x01)
+        val sei = nal(0x4E, 0x01)
+        assertContentEquals(
+            HevcDecoder.parameterSetNals(vps + sps + pps),
+            HevcDecoder.parameterSetNals(vps + sei + sps + pps),
+        )
+    }
+
+    /** The regression: same parameter sets, different SEI, must not be a change. */
+    @Test
+    fun sameParameterSetsWithADifferentSeiIsNotAChange() {
+        val sps = nal(0x67, 0x42, 0x00)
+        val pps = nal(0x68, 0xCE)
+        val first = nal(0x06, 0x05, 0x01) + sps + pps
+        val second = nal(0x06, 0x05, 0x02) + sps + pps
+
+        assertTrue(EncoderPresentPath.parameterSetsChanged(true, first, second))
+        assertFalse(
+            EncoderPresentPath.parameterSetsChanged(
+                true,
+                HevcDecoder.parameterSetNals(first),
+                HevcDecoder.parameterSetNals(second),
+            )
+        )
+    }
+
+    /** A real SPS change still has to rebuild the decoder. */
+    @Test
+    fun aChangedSpsIsStillAChange() {
+        val pps = nal(0x68, 0xCE)
+        val before = HevcDecoder.parameterSetNals(nal(0x67, 0x42, 0x00) + pps)
+        val after = HevcDecoder.parameterSetNals(nal(0x67, 0x42, 0x28) + pps)
+        assertTrue(EncoderPresentPath.parameterSetsChanged(true, before, after))
+    }
+
+    @Test
+    fun aBlobWithNoParameterSetsIsEmpty() {
+        assertContentEquals(ByteArray(0), HevcDecoder.parameterSetNals(nal(0x06, 0x05)))
+    }
+}


### PR DESCRIPTION
A Nano rebuilt its MediaCodec once a second, on every IDR, to the same 1280x720 format, and re-requested a live-view enable each time.

SwiftCore.hevcCsd returns a blob for every access unit, not only the ones carrying parameter sets: a keyframe yields 31 bytes of SPS+PPS, and the next P-frame yields 16 KB with no parameter sets in it at all. Both were taken as the new baseline, so the comparison alternated between them and reported a parameter-set change on every access unit.

An access unit with no parameter sets cannot signal a parameter-set change, and must not become the baseline the next keyframe is compared against, so skip the whole block for those. Compare parameter sets rather than whole blobs while we are here: only VPS/SPS/PPS decide whether MediaCodec has to be reconfigured, which is what OpenPocketViewCore EncoderPresentPath already does by taking them separately.

Verified on an Osmo Nano (Pixel 10, Android 17): 1 decoder creation and 0 parameter-set changes across 586 access units, against 21 and 20 before. Live view still presents, no artifacts.

## What & why

<!-- What does this PR change, and why? Link any related issue. -->

## TestFlight notes

<!--
If this PR changes Sources/, Tests/, ios/, Package.swift, scripts/, or justfile, replace
ios/TestFlight/WhatToTest.en-US.txt:
- New and changed (1-6 bullets)
- Fixes (1-8 bullets)
- What to test (1-5 concrete actions)
Write for camera operators. For a build with no tester-facing app behavior, say that plainly.
-->

## Checklist

- [ ] `just check` passes.
- [ ] Native production changes: `just native-check` passes, or the relevant platform check is noted.
- [ ] Commits follow Conventional Commits.
- [ ] No captures, Wi-Fi passwords, unofficial LUT dumps, signing material, or other secrets.
- [ ] Docs/CHANGELOG updated if behavior or setup changed. Public handbook pages updated when protocol, app, or setup visitors read has changed.
- [ ] TestFlight-triggering changes include reviewed `ios/TestFlight/WhatToTest.en-US.txt` copy.
- [ ] iOS release PRs: bump `MARKETING_VERSION` in `ios/Config/Version.xcconfig` when starting a new version train.
