### PR TITLE
feat: switch shooting mode from the Android settings panel

### DIFF
--- a/Apps/Android/Play/WhatToTest.en-US.txt
+++ b/Apps/Android/Play/WhatToTest.en-US.txt
@@ -1,16 +1,16 @@
 New and changed
 
-- Xtra bodies (Edge Pro and the rest of that rebrand line) should join on their own link instead of stalling on Open datalink. Genuine Osmo Nano and Pocket still join as before.
+- While live, Operator Setup then Controls has a Shooting Mode row. Switch Video, Photo, and the time-based modes from there. The row follows a mode changed on the body itself.
 - Pair over Bluetooth, join the camera's Wi-Fi, and watch a live view with waveform, parade, and assists.
-- Open clips from the camera. LUT, false colour, peaking, and zebra grade the small preview. Share and Save still use the original camera file.
+- Record, ISO, white balance, and zoom from the phone. The gimbal stick sits with zoom.
 
 Fixes
 
-- An Xtra that used to sit on Open datalink should now handshake and show live view. A Nano or Pocket beside it must still use the usual Osmo link.
+- On a Nano, Photo now actually switches instead of staying on Video. Video back to Photo should ack and the shutter should take a still, not start a clip.
 - Live view should come up in a couple of seconds after Wi-Fi joins, not sit on Waiting for live view.
 
 What to test
 
-- If you have an Xtra, pair it. Confirm it is named as Xtra, live view fills, and you can open a clip from the camera.
-- Pair an Osmo Nano or Pocket beside it and confirm that body still joins as a DJI camera, with live view in a couple of seconds.
-- Record a short take, then open it in the library. Share should send the original file, not a small preview.
+- Pair a Nano, go live, open Operator Setup, Controls. Switch Video to Photo and back. The body should follow; Photo should take a still.
+- If you have a Pocket 4, do the same Video to Photo check. On a Nano, stay on Video and Photo only; skip SuperNight, HyperLapse, SlowMo, and TimeLapse until those are proven.
+- Record a short take in Video, then open it in the library. Share should send the original file, not a small preview.

--- a/Apps/Android/Play/whatsnew/whatsnew-en-US
+++ b/Apps/Android/Play/whatsnew/whatsnew-en-US
@@ -1,1 +1,1 @@
-Xtra cameras should join and show live view instead of stalling on Open datalink. Genuine Osmo Nano and Pocket still join as before. Pair, record, and library share are unchanged on those bodies.
+While live, Operator Setup then Controls can switch shooting mode. On a Nano, Video and Photo should actually change on the body. Pair, live view, record, and library share are unchanged.

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/OperatorSetup.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/OperatorSetup.kt
@@ -68,6 +68,7 @@ import com.opencapture.openpocketcine.assists.LiveAssistTool
 import com.opencapture.openpocketcine.assists.LiveZebra
 import com.opencapture.openpocketcine.assists.ParadeMode
 import com.opencapture.openpocketcine.assists.PeakingColor
+import com.opencapture.openpocketcine.session.CameraCommands
 import com.opencapture.openpocketcine.assists.PeakingSense
 import com.opencapture.openpocketcine.assists.ScopeGuides
 import com.opencapture.openpocketcine.assists.VectorscopeZoom
@@ -116,6 +117,9 @@ object SettingsHelpCopy {
     const val FRAME_IO =
         "Sign in to upload clips from the share popup. Frame.io needs the internet, so the phone hops off the camera Wi‑Fi for the upload."
     const val RECORD_CONFIRMATION = "Ask before starting or stopping recording to prevent mistaps."
+    const val SHOOTING_MODE =
+        "Switch the camera between Video, Photo and the time-based modes. The camera reports " +
+            "the mode back, so this follows a change made on the body itself."
     const val HAPTICS = "Short confirmation pulses for critical switches and setting changes."
     const val JOYSTICK_SENSITIVITY =
         "How far a stick throw moves the gimbal. 4 is the current feel. 5 reaches full speed sooner; 1 is the slowest."
@@ -786,7 +790,7 @@ private fun SettingsContentPane(
                             LinkRows(model, isLive, phaseLabel, bars)
                         OperatorSettingsTab.SHARING -> SharingRows()
                         OperatorSettingsTab.ASSIST -> AssistRows(model, statusColorMode, onOpenLut)
-                        OperatorSettingsTab.CONTROLS -> ControlsRows(model)
+                        OperatorSettingsTab.CONTROLS -> ControlsRows(model, isLive)
                         OperatorSettingsTab.DISPLAY ->
                             DisplayRows(model, isLive, expandedDisp, onExpandDisp)
                         OperatorSettingsTab.STORAGE -> StorageRows(model, onClearCache)
@@ -1209,9 +1213,55 @@ private fun ScopeGuideRows(guides: ScopeGuides, onChange: (ScopeGuides) -> Unit)
     }
 }
 
+/**
+ * Shooting-mode picker, mirroring the iOS capture sheet.
+ *
+ * Laid out as two strips of three rather than one six-wide segment so "HyperLapse" and
+ * "SuperNight" stay readable, keeping the camera's own carousel order reading left to right,
+ * top to bottom. Selection comes from the camera's `0x02/0x80` status push, so it follows a
+ * mode changed on the body itself; [CameraCommands.shootingModeCarousel] is the only source of
+ * values written back.
+ */
 @Composable
-private fun ControlsRows(model: AppModel) {
+private fun ShootingModeRow(model: AppModel, view: View) {
+    val status by model.session.status.collectAsState()
+    val cameraName = model.session.connectedCamera?.model?.name
+    val carousel = remember(cameraName) { CameraCommands.shootingModeCarousel(cameraName) }
+    val selectedLabel = CameraCommands.shootingModeLabel(status.shootingMode)
+    SettingsInlineRow(
+        title = "Shooting Mode",
+        help = SettingsHelpCopy.SHOOTING_MODE,
+        showTopDivider = false,
+        stacked = true,
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            carousel.chunked(3).forEach { row ->
+                val labels = row.mapNotNull { CameraCommands.shootingModeLabel(it) }
+                SettingsSegmented(
+                    options = labels,
+                    // Blank keeps the whole strip unselected when the mode lives in the other row.
+                    selected = if (selectedLabel in labels) selectedLabel.orEmpty() else "",
+                    compact = true,
+                ) { label ->
+                    val raw = row.firstOrNull { CameraCommands.shootingModeLabel(it) == label }
+                    if (raw != null && raw != status.shootingMode) {
+                        operatorHaptic(view, model.hapticsEnabled)
+                        model.setShootingMode(raw)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ControlsRows(model: AppModel, isLive: Boolean) {
     val view = LocalView.current
+    if (isLive) {
+        SettingsRowCard(title = "Capture") {
+            ShootingModeRow(model, view)
+        }
+    }
     SettingsRowCard {
         SettingsSwitchInlineRow(
             title = "Record Confirmation",

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/session/CameraCommands.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/session/CameraCommands.kt
@@ -297,6 +297,55 @@ object CameraCommands {
             shootingMode == SHOOT_PHOTO_POCKET4 ||
             shootingMode == SHOOT_SUPER_NIGHT
 
+    /**
+     * Label for a tabled `0x02/0xE1` value, or null when the camera reports one we do not know.
+     * Both photo encodings read back as "Photo" — the body decides which it uses.
+     */
+    fun shootingModeLabel(raw: Int): String? =
+        when (raw) {
+            SHOOT_SLOWMO -> "SlowMo"
+            SHOOT_VIDEO -> "Video"
+            SHOOT_TIMELAPSE -> "TimeLapse"
+            SHOOT_PHOTO, SHOOT_PHOTO_POCKET4 -> "Photo"
+            SHOOT_HYPERLAPSE -> "HyperLapse"
+            SHOOT_SUPER_NIGHT -> "SuperNight"
+            else -> null
+        }
+
+    /**
+     * Photo is the one mode whose `0x02/0xE1` value is body-dependent: Pocket 4 / 4 Pro take
+     * `0x17`, and a Nano rejects that and takes `0x05`.
+     */
+    fun photoModeRaw(cameraName: String?): Int {
+        val n = cameraName.orEmpty().lowercase().replace(" ", "")
+        return if (n.contains("pocket4")) SHOOT_PHOTO_POCKET4 else SHOOT_PHOTO
+    }
+
+    /**
+     * The camera's own on-screen carousel order — Video, Photo, TimeLapse, HyperLapse,
+     * SuperNight, SlowMo — which is not the numeric order. The wire enum is sparse and
+     * unordered, so this is tabled and never computed.
+     *
+     * Only ever send a value from this table. Sweeping the `0x02/0xE1` value space froze a Nano
+     * solid and needed a power cycle, so an unlisted mode must be refused rather than passed
+     * through (Osmosis `MEDIA_PROTOCOL.md` §13a, DJI-Remote `engine_media.c`).
+     *
+     * Panorama (`0x0c`) is documented but left out: no hardware here has confirmed it.
+     *
+     * Note this is `0x02/0xE1`, never `0x02/0x02`. That opcode is nominally DJI's four-value
+     * *work* mode, but on a Nano it **is** record control — a "Video" entry mapped to `[01]`
+     * would start a recording behind the operator's back.
+     */
+    fun shootingModeCarousel(cameraName: String?): List<Int> =
+        listOf(
+            SHOOT_VIDEO,
+            photoModeRaw(cameraName),
+            SHOOT_TIMELAPSE,
+            SHOOT_HYPERLAPSE,
+            SHOOT_SUPER_NIGHT,
+            SHOOT_SLOWMO,
+        )
+
     fun shootPhoto(): ByteArray = byteArrayOf(0x01)
 
     /** `0x02/0x2E` 1-byte EV. `0x10` = 0.0; ⅓-stop steps, −9…+9 thirds. */

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/session/Models.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/session/Models.kt
@@ -260,16 +260,11 @@ data class CameraStatus(
 ) {
     val shootingModeLabel: String
         get() =
-            when (shootingMode) {
-                0x00 -> "SlowMo"
-                0x01 -> "Video"
-                0x02 -> "TimeLapse"
-                0x05, 0x17 -> "Photo"
-                0x0A -> "HyperLapse"
-                0x28 -> "SuperNight"
-                -1 -> if (inPlayback) "Playback" else "Capture"
-                else -> "0x%02X".format(shootingMode)
-            }
+            CameraCommands.shootingModeLabel(shootingMode)
+                ?: when (shootingMode) {
+                    -1 -> if (inPlayback) "Playback" else "Capture"
+                    else -> "0x%02X".format(shootingMode)
+                }
 
     val expoLabel: String
         get() =

--- a/Sources/OpenPocketCineAndroidFacade/AndroidSessionWire.swift
+++ b/Sources/OpenPocketCineAndroidFacade/AndroidSessionWire.swift
@@ -529,10 +529,10 @@ public enum AndroidSessionWire {
         case .shootPhoto:
             return Commands.shootPhoto(seq: seq)
         case .setShootingMode:
-            guard let raw = parseUInt8(extra), let mode = ShootingMode(rawValue: raw) else {
-                return nil
-            }
-            return Commands.setShootingMode(mode, seq: seq)
+            // Not `ShootingMode(rawValue:)`: the Nano's Photo is 0x05 and has no case, so going
+            // through the enum returned nil and the mode never reached the wire.
+            guard let raw = parseUInt8(extra) else { return nil }
+            return Commands.setShootingMode(raw: raw, seq: seq)
         case .setEv:
             guard let raw = parseUInt8(extra), let ev = EvComp(rawValue: raw) else { return nil }
             return Commands.setEv(ev, seq: seq)

--- a/Sources/OpenPocketViewCore/CameraControl.swift
+++ b/Sources/OpenPocketViewCore/CameraControl.swift
@@ -45,6 +45,22 @@ public enum ShootingMode: UInt8, CaseIterable, Sendable {
     }
 
     public var isPhoto: Bool { self == .photo || self == .superNight }
+
+    /// Every `0x02/0xE1` value a supported body accepts, including the Nano's Photo `0x05`, which
+    /// has no case of its own because `photo` carries the Pocket 4 encoding `0x17`.
+    ///
+    /// The wire enum is sparse and unordered, so it is tabled and never computed, and nothing
+    /// outside this set may be sent: sweeping the opcode's value space froze a Nano solid and
+    /// needed a power cycle. Panorama `0x0c` is documented but omitted — unconfirmed on hardware.
+    public static let tabledRawValues: Set<UInt8> = [
+        0x00,  // SlowMo
+        0x01,  // Video
+        0x02,  // TimeLapse
+        0x05,  // Photo (Nano)
+        0x0A,  // HyperLapse
+        0x17,  // Photo (Pocket 4 / 4 Pro)
+        0x28,  // SuperNight
+    ]
 }
 
 /// Osmosis §14 / Mimo 2026-08-14 `0x02/0x8E` pids.

--- a/Sources/OpenPocketViewCore/Commands.swift
+++ b/Sources/OpenPocketViewCore/Commands.swift
@@ -221,6 +221,18 @@ public enum Commands {
         camera(0xE1, [mode.rawValue], seq: seq)
     }
 
+    /// `0x02/0xE1` from a raw wire value, for callers that carry the byte rather than the case —
+    /// Photo is body-dependent (`0x17` on a Pocket 4, `0x05` on a Nano), and only one of those
+    /// can be `ShootingMode.photo`.
+    ///
+    /// Returns nil for anything outside `ShootingMode.tabledRawValues`. That refusal is the point:
+    /// sweeping this opcode's value space froze a Nano solid and needed a power cycle, so an
+    /// unrecognised mode must never reach the wire.
+    public static func setShootingMode(raw: UInt8, seq: UInt16 = 0) -> Duml.Frame? {
+        guard ShootingMode.tabledRawValues.contains(raw) else { return nil }
+        return camera(0xE1, [raw], seq: seq)
+    }
+
     /// `0x02/0x8E` GET = `00 01 <pid:u16-LE>`.
     public static func paramGet(_ param: CameraParam, seq: UInt16 = 0) -> Duml.Frame {
         let pid = param.rawValue

--- a/Tests/OpenPocketViewCoreTests/ShootingModeRawTests.swift
+++ b/Tests/OpenPocketViewCoreTests/ShootingModeRawTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+
+@testable import OpenPocketViewCore
+
+/// Photo is the one shooting mode whose `0x02/0xE1` value is body-dependent — `0x17` on a
+/// Pocket 4, `0x05` on a Nano — so only one of the two can be `ShootingMode.photo`. Encoding
+/// through the enum dropped the other on the floor and the mode never reached the wire.
+@Suite struct ShootingModeRawTests {
+    @Test func rawEncodesBothPhotoEncodings() {
+        #expect(Commands.setShootingMode(raw: 0x05) != nil)  // Nano
+        #expect(Commands.setShootingMode(raw: 0x17) != nil)  // Pocket 4
+        // The enum only carries the Pocket 4 one, which is the bug this overload exists for.
+        #expect(ShootingMode(rawValue: 0x05) == nil)
+        #expect(ShootingMode(rawValue: 0x17) == .photo)
+    }
+
+    @Test func rawEncodesEveryTabledMode() {
+        for raw in ShootingMode.tabledRawValues {
+            #expect(Commands.setShootingMode(raw: raw) != nil, "tabled mode \(raw) must encode")
+        }
+    }
+
+    /// The refusal is the safety property: sweeping this opcode froze a Nano solid.
+    @Test func rawRefusesUntabledValues() {
+        for raw in [0x03, 0x04, 0x0C, 0x18, 0x99, 0xFF] as [UInt8] {
+            #expect(Commands.setShootingMode(raw: raw) == nil, "untabled \(raw) must be refused")
+        }
+    }
+
+    @Test func rawMatchesTheEnumFrameForSharedValues() {
+        for mode in ShootingMode.allCases {
+            let viaEnum = Commands.setShootingMode(mode, seq: 7)
+            let viaRaw = Commands.setShootingMode(raw: mode.rawValue, seq: 7)
+            #expect(viaRaw == viaEnum, "\(mode.label) must encode identically")
+        }
+    }
+}

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,16 +1,16 @@
 New and changed
 
-- Xtra bodies should join instead of sitting on Open datalink. The phone tells them apart from a DJI original by the advertised Bluetooth name.
+- No new iPhone chrome in this build. Pairing, live view, and capture stay as they were.
 - Pair over Bluetooth, join the camera's Wi-Fi, and watch a live view. Record, ISO, white balance, and zoom from the phone.
 - Open clips from the camera. LUT, false colour, peaking, and zebra grade the picture. Share and Save still use the original camera file.
 
 Fixes
 
-- An Xtra that used to stall after Wi-Fi joined should now handshake and show live view. A Pocket or Nano beside it must still join as before.
-- Live view should come up in a couple of seconds after Wi-Fi joins, not sit on Waiting for live view. Zoom must keep the live picture, not just HUD and stick.
+- No tester-facing iPhone fixes in this build. Live view should still come up in a couple of seconds after Wi-Fi joins, not sit on Waiting for live view.
+- Zoom must keep the live picture, not just HUD and stick. COLOR still lists what this camera has: D-Log2 only on Pocket 4 Pro.
 
 What to test
 
-- If you have an Xtra, pair it. Confirm live view fills and you can open a clip from the camera.
-- Pair a Pocket or Nano and confirm it still joins, with live view in a couple of seconds. Cycle zoom; the picture must stay.
+- Pair a Pocket, join Wi-Fi, and confirm live view fills in a couple of seconds. Cycle zoom; the picture must stay.
 - Record a short take, then open it in the library with LUT on. Share should send the original file, not a small preview.
+- On a 4 Pro, COLOR should include D-Log2. On Pocket 3, COLOR is Normal / HDR / D-Log M.


### PR DESCRIPTION
Tested on Osmo Nano.

Modes and carousel order per Osmosis MEDIA_PROTOCOL.md 13a.

Will try on Xtra once other PR lands.

I'd suggest moving mode change outside of where it is, I couldn't find it at first. Lets move it to the preview screen in a follow up PR?

## What & why

<!-- What does this PR change, and why? Link any related issue. -->

## TestFlight notes

<!--
If this PR changes Sources/, Tests/, ios/, Package.swift, scripts/, or justfile, replace
ios/TestFlight/WhatToTest.en-US.txt:
- New and changed (1-6 bullets)
- Fixes (1-8 bullets)
- What to test (1-5 concrete actions)
Write for camera operators. For a build with no tester-facing app behavior, say that plainly.
-->

## Checklist

- [ ] `just check` passes.
- [ ] Native production changes: `just native-check` passes, or the relevant platform check is noted.
- [ ] Commits follow Conventional Commits.
- [ ] No captures, Wi-Fi passwords, unofficial LUT dumps, signing material, or other secrets.
- [ ] Docs/CHANGELOG updated if behavior or setup changed. Public handbook pages updated when protocol, app, or setup visitors read has changed.
- [ ] TestFlight-triggering changes include reviewed `ios/TestFlight/WhatToTest.en-US.txt` copy.
- [ ] iOS release PRs: bump `MARKETING_VERSION` in `ios/Config/Version.xcconfig` when starting a new version train.
