### PR TITLE
ci: move editorconfig-checker action to v3 and mark the gitleaks workspace safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Gitleaks
         # Digest-pinned for reproducibility. Update the version manually when needed. v8.30.1
         uses: docker://ghcr.io/gitleaks/gitleaks:v8.30.1@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f
+        # The container's uid differs from the checkout owner on some runner images, and
+        # git then refuses the repo ("dubious ownership"). Mark the workspace safe via env.
+        env:
+          GIT_CONFIG_COUNT: "1"
+          GIT_CONFIG_KEY_0: safe.directory
+          GIT_CONFIG_VALUE_0: /github/workspace
         with:
           args: "detect --source=. --redact --no-banner --config=.gitleaks.toml"
 
@@ -101,7 +107,8 @@ jobs:
           fail: true
 
       - name: EditorConfig check
-        uses: editorconfig-checker/action-editorconfig-checker@d2ed4fd072ae6f887e9407c909af0f585d2ad9f4 # v2
+        # editorconfig-checker 4.0 renamed its release assets; the v2 action only knows `ec-*`.
+        uses: editorconfig-checker/action-editorconfig-checker@51f63319f592f97930c73d9c46184d20bd206393 # v3.0.0
 
       - name: Actionlint
         # Digest-pinned for reproducibility. Update the version manually when needed. v1.7.12


### PR DESCRIPTION
## Why

Every Meta checks job has failed since 2026-09-03, including the last push to main (aec053f), with:

```
Error: The binary 'ec-linux-amd64*' not found
```

editorconfig-checker 4.0.0 renamed its release assets from `ec-*` to `editorconfig-checker-*`. The pinned v2 action downloads "latest" and only knows the old name. v3.0.0 of the action (released the same day) handles both.

Three dependabot runs on 2026-09-03 also failed earlier in the same job, in gitleaks:

```
[git] fatal: detected dubious ownership in repository at '/github/workspace'
```

The step now passes `safe.directory` into the container through `GIT_CONFIG_*` env, so it no longer depends on which uid the runner image gives the checkout.

## Test plan

- [ ] Meta checks green on this PR
- [ ] CI gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJXipRLRC8yAkfQV6mVzxS