### PR TITLE
ci: exempt dependabot from the tester-notes requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,8 @@ jobs:
           ./scripts/prepare-android-testers-test.sh
 
       - name: Require reviewed notes for TestFlight-triggering pull requests
-        if: ${{ github.event_name == 'pull_request' }}
+        # Dependency bumps change no operator-visible behavior, so dependabot is exempt.
+        if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
@@ -76,7 +77,8 @@ jobs:
           fi
 
       - name: Require reviewed notes for Play-triggering pull requests
-        if: ${{ github.event_name == 'pull_request' }}
+        # Dependency bumps change no operator-visible behavior, so dependabot is exempt.
+        if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |


### PR DESCRIPTION
## Why

Dependabot's gradle bumps (#228, #229, #230) fail Meta checks at "Require reviewed notes for Play-triggering pull requests" because any change under `Apps/Android/` demands new TestFlight/Play tester notes. A version bump has no operator-visible behavior to describe, and dependabot rewrites its branch on every rebase, so notes cannot live there.

Both notes-requirement steps now skip when the actor is `dependabot[bot]`. The notes validators (format, caps, jargon) still run on every PR.

## Test plan

- [ ] CI gate green here
- [ ] #228, #229, #230 pass Meta checks after a branch update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJXipRLRC8yAkfQV6mVzxS