### PR TITLE
ci: judge tester-notes updates by the branch's commits, not a diff against main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,10 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          changed_files="$(git diff --name-only "$BASE_SHA"...HEAD)"
+          # Files touched by this branch's own commits. A content diff against main
+          # goes blank once a sibling PR lands the same notes, and then a PR that did
+          # write notes fails here.
+          changed_files="$(git log --format= --name-only "$BASE_SHA..HEAD" | sort -u)"
           if grep -Eq '^(Sources/|Tests/|ios/|Package\.swift$|scripts/ios-|scripts/setup-xcode-cloud\.sh$)' <<< "$changed_files"; then
             if ! grep -Fxq 'ios/TestFlight/WhatToTest.en-US.txt' <<< "$changed_files"; then
               echo "Update ios/TestFlight/WhatToTest.en-US.txt with plain-language changes and test steps." >&2
@@ -82,7 +85,10 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          changed_files="$(git diff --name-only "$BASE_SHA"...HEAD)"
+          # Files touched by this branch's own commits. A content diff against main
+          # goes blank once a sibling PR lands the same notes, and then a PR that did
+          # write notes fails here.
+          changed_files="$(git log --format= --name-only "$BASE_SHA..HEAD" | sort -u)"
           if grep -Eq '^(Apps/Android/|Sources/OpenPocketViewCore/|Sources/OpenPocketCineAndroidFacade/|Sources/CJNI/|Package\.swift$|scripts/android-|scripts/ci-install-swift-android\.sh$)' <<< "$changed_files"; then
             if ! grep -Fxq 'Apps/Android/Play/WhatToTest.en-US.txt' <<< "$changed_files"; then
               echo "Update Apps/Android/Play/WhatToTest.en-US.txt with plain-language changes and test steps." >&2


### PR DESCRIPTION
## Why

#265 (and next #263, #268, #267) fail Meta checks at "Require reviewed notes for TestFlight-triggering pull requests" after merging main. All open PRs carry one shared tester-notes set so the files stop conflicting on every merge. Once #264 and #266 landed that set on main, `git diff BASE...HEAD` shows no change to the notes on the remaining branches, and the gate reads that as "no notes written".

The steps now list files touched by the branch's own commits (`git log --format= --name-only BASE_SHA..HEAD`). A PR that changes app code without ever committing to the notes still fails; a PR whose notes commit converged with main passes.

## Test plan

- [ ] CI gate green here
- [ ] #265 passes Meta checks after a branch update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJXipRLRC8yAkfQV6mVzxS