### PR TITLE
ci: key the dependabot notes exemption on the PR author

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,8 @@ jobs:
 
       - name: Require reviewed notes for TestFlight-triggering pull requests
         # Dependency bumps change no operator-visible behavior, so dependabot is exempt.
-        if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
+        # Keyed on the PR author: `github.actor` is whoever last pushed or updated the branch.
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]' }}
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
@@ -81,7 +82,8 @@ jobs:
 
       - name: Require reviewed notes for Play-triggering pull requests
         # Dependency bumps change no operator-visible behavior, so dependabot is exempt.
-        if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
+        # Keyed on the PR author: `github.actor` is whoever last pushed or updated the branch.
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]' }}
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |


### PR DESCRIPTION
## Why

#270 exempted dependabot from the tester-notes gate via `github.actor`, but that is whoever last pushed or updated the branch. After a manual "update branch" the actor is the maintainer, so #228, #229, #230 failed the gate again. `github.event.pull_request.user.login` is the PR author and does not change.

## Test plan

- [ ] CI gate green here
- [ ] #228, #229, #230 pass Meta checks after a branch update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJXipRLRC8yAkfQV6mVzxS