### PR TITLE
docs: record SoftAP live as one unicast client

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,6 +29,12 @@ _Avoid_: hotspot (except when naming the iOS API)
 UDP port 9004 DUML transport between phone and camera.
 _Avoid_: media port, stream
 
+**One client**:
+Live HEVC/AVC on the camera SoftAP is unicast UDP to one phone 5-tuple.
+Camera multicast is won't-do. A second-screen watcher would be a
+phone-as-encoder relay on another interface — not in this build.
+_Avoid_: camera multicast, NDI (as this path), SRT (as this path)
+
 **Enable-once**:
 `0x09/0xa8` starts live view and is the only PLI; it is not a 1 Hz keyframe loop.
 _Avoid_: IDR loop, live-start (alone)

--- a/docs/live-session.md
+++ b/docs/live-session.md
@@ -8,6 +8,8 @@ Freeze-in-seconds vs ACK windows vs repair owner:
 ## 5-tuple
 
 One UDP flow: camera `192.168.2.1:9004` is the **remote** only.
+That flow is **unicast** to the associated client. Camera multicast is
+won't-do ([one client vs many](protocol-notes.md#one-client-vs-many)).
 
 - iOS binds the camera DHCP IPv4 plus an **ephemeral local port**
   (`NWParameters.requiredLocalEndpoint` port 0).
@@ -223,3 +225,4 @@ the live well repeats it after 8 s with no picture when a tunnel is on.
 - Live-path SLOs: [`PERFORMANCE.md`](PERFORMANCE.md)
 - Wire format: [protocol handbook live view](https://openpocketcine.app/docs/protocol/live-view/)
   (Markdown source: `handbook/src/content/docs/protocol/live-view.md`)
+- One client vs many (camera multicast won't-do): [`protocol-notes.md`](protocol-notes.md#one-client-vs-many)

--- a/docs/protocol-notes.md
+++ b/docs/protocol-notes.md
@@ -14,3 +14,78 @@ Implementation lives in `Sources/OpenPocketViewCore/`.
 Recording resolution × aspect × fps (official DJI tables + wire bytes):
 [`osmo-recording-formats.md`](osmo-recording-formats.md). FORMAT lists
 `camcap_video_format` pairs; aspect is the resolution byte.
+
+## One client vs many
+
+Spike [#86](https://github.com/erik-sutton95/OpenPocketCine/issues/86) /
+discussion [#53](https://github.com/erik-sutton95/OpenPocketCine/discussions/53).
+Do not build Sharing UI from this note. Do not commit captures.
+
+Live HEVC/AVC is **unicast UDP** on the datalink 5-tuple
+(`192.168.2.1:9004` → the associated phone's DHCP IPv4 and ephemeral port,
+pktType `0x02`). The camera does not multicast or broadcast that media.
+A second phone on the SoftAP does not get a copy.
+
+| Path | Call |
+| --- | --- |
+| Camera SoftAP multicast / multi-client live | **won't-do** |
+| Phone-as-encoder watcher relay (operator stays on SoftAP; watchers on another interface) | Follow-on architecture, not camera multicast. Sharing tab stays parked. |
+| Keep 1:1 | **Yes** — one phone talks to one Pocket |
+
+Public summary: [live view](https://openpocketcine.app/docs/protocol/live-view/).
+5-tuple and ACK: [`live-session.md`](live-session.md).
+
+### Capture evidence
+
+Filenames only. Offline helpers: `tools/duml_parse.py`, `tools/extract_liveview.py`.
+
+| Take | Camera → client | Other 9004 | Multicast / IGMP from `192.168.2.1` |
+| --- | --- | --- | --- |
+| `live1.pcap` (~97 s) | `192.168.2.1:9004` → `192.168.2.231:56739` (40 MB / 37024 pkts). Return is ACK/control (501 kB). | none | none |
+| `mimo-disconnect-20260822-105228.pcap` | `192.168.2.1:9004` → `192.168.2.249:63270` (55 MB / 50326 pkts) | Off-SoftAP `192.168.1.148` sent 155 datagrams to `:9004` and got **zero** replies | none |
+| `mimo-settings-1.pcapng` (~300 s live) | `192.168.2.1:9004` → `192.168.2.198:59003` (155 MB / 137860 pkts) | Phone probed `192.168.4.1:9004` (595 pkts, **0** bytes back) | Camera sourced **no** 224/4, no IGMP. mDNS `224.0.0.251:5353` is the **phone** (including `_djimimo._tcp.local`), not the body |
+
+Same picture in all three: one unicast 5-tuple carries the picture. Broadcast
+`192.168.2.255` never carried video. Handshake payload is window/MTU (`baseSeq`,
+proposed window 100, MTU 1472) — it does not list extra clients.
+
+### Second `0x09/0xa8`
+
+These takes are one STA. A two-phone steal-vs-duplicate capture is **not** in
+`captures/`. Do not collect it by spamming enable from a second client —
+`0x09/0xa8` is live-start **and** the only PLI; a second send resets the GOP
+and can black the feed that is already up.
+
+Because the camera already unicasts to one dest IP:port, a second phone does
+not receive a copy on the wire. A second handshake would have to **retarget**
+that 5-tuple (steal) for the new phone to see video. Treat steal as the working
+hypothesis; do not prove it with a 1 Hz enable loop.
+
+### Phone relay and dual-interface
+
+If a watcher exists later, the operator phone re-encapsulates the HEVC/AVC it
+already received — it does not ask the camera for a second stream.
+
+**iOS.** The SoftAP is internetless. iOS keeps **cellular as the default
+route**; camera sockets must pin Wi-Fi (`NWParameters.requiredLocalEndpoint` =
+camera DHCP IPv4, `prohibitedInterfaceTypes = [.cellular]`,
+`requiredInterface` when known). Frame.io already hops **off** the camera AP
+for the internet. Joining SoftAP does not by itself give a second Wi-Fi AP for
+watchers — Personal Hotspot while associated to the camera AP is not a
+supported backhaul. USB/Ethernet tethering is the plausible iOS extra
+interface. `mimo-settings-1.pcapng` shows the phone still had home-LAN and
+mDNS while the camera 5-tuple was live; that is default-route / other-interface
+traffic, not a second camera media port.
+
+**Android.** `bindProcessToNetwork` pins the **process** to the SoftAP. A relay
+socket would have to bind to a different `Network` (STA+hotspot on some
+chipsets), not inherit the process default. Do not unbind the live datalink to
+make that work.
+
+**Bonjour / mDNS.** Useful only to discover a **relay** on the watcher LAN.
+It is not camera multicast. The body never sourced mDNS in these takes. Mimo
+advertises `_djimimo._tcp.local` from the phone.
+
+Do not promise NDI/SRT in the same breath. One-phone-many-Pockets is
+discussion [#238](https://github.com/erik-sutton95/OpenPocketCine/discussions/238),
+not this note.

--- a/handbook/src/content/docs/protocol/duml-transport.md
+++ b/handbook/src/content/docs/protocol/duml-transport.md
@@ -15,8 +15,9 @@ Port **9004** for the Pocket family. First a TCP `:7001` “poke”:
    (`tcp_output`); Mimo and the iOS shell leave it up (the camera pushes
    `0x21/0x06` on it). Video never uses this socket — only UDP 9004.
 
-Then a 40-byte UDP handshake, then register + subscribe. One UDP 9004
-5-tuple stays for control and live view. Pin that socket to the camera
+Then a 40-byte UDP handshake, then register + subscribe. One **unicast**
+UDP 9004 5-tuple stays for control and live view (the camera does not
+multicast live media — [live view](../live-view/)). Pin that socket to the camera
 SoftAP (iOS `NWConnection` to `192.168.2.1:9004` with an ephemeral local
 port; Android `Network.bindSocket` on an unbound datagram, bind `0.0.0.0:0`,
 then `connect`). Camera 9004 is the remote — do not bind the client to

--- a/handbook/src/content/docs/protocol/ios.md
+++ b/handbook/src/content/docs/protocol/ios.md
@@ -6,7 +6,7 @@ description: Simulator limits, Hotspot Configuration, Local Network, and CoreBlu
 Compared with Osmosis on Android:
 
 - **Must run on a physical iPhone.** BLE and Wi-Fi-join do not work in the Simulator.
-- **Joining the AP:** `NEHotspotConfiguration` (needs the *Hotspot Configuration* entitlement). No `bindProcessToNetwork` equivalent — reach `192.168.2.1` by pinning sockets to Wi-Fi (`NWParameters.requiredInterfaceType = .wifi`).
+- **Joining the AP:** `NEHotspotConfiguration` (needs the *Hotspot Configuration* entitlement). No `bindProcessToNetwork` equivalent — reach `192.168.2.1` by pinning sockets to the camera DHCP IPv4 (`NWParameters.requiredLocalEndpoint`, ephemeral local port). The SoftAP is internetless; iOS keeps **cellular as the default route**, so camera sockets also set `prohibitedInterfaceTypes = [.cellular]`. That does not yield a second Wi-Fi AP for watchers — Personal Hotspot while associated to the camera AP is not a supported backhaul. USB/Ethernet tethering is the plausible extra interface. Live media stays unicast to that one phone ([live view](../live-view/)).
 - **Local Network permission** (`NSLocalNetworkUsageDescription`) is required to talk to `192.168.2.1`, plus a Bluetooth usage string.
 - **No MAC/OUI over CoreBluetooth.** Xtra 10004 identification keys off the BLE name (`xtra` / `edge`), not a MAC.
 - **Pace `fff5` writes** with `.withoutResponse` + delays, same as Android.

--- a/handbook/src/content/docs/protocol/live-view.md
+++ b/handbook/src/content/docs/protocol/live-view.md
@@ -18,6 +18,8 @@ Nano uses the same DJI `00 00 01 ff` marker and fragment layout; SPS `67 64 00 1
 
 The video is on the [DUML datalink](../duml-transport/) itself — **UDP port 9004**, carried as datalink **pktType `0x02`** packets. It is *not* on a separate port or protocol.
 
+That media is **unicast** to one client 5-tuple: camera `192.168.2.1:9004` → the phone's camera DHCP IPv4 and an ephemeral local port. The body does not multicast or broadcast HEVC/AVC, and a second phone on the SoftAP does not get a copy. Operator Setup → Sharing stays parked. A watcher feed would be a phone-side relay on another interface, not camera multicast.
+
 ## Enable
 
 Pocket live-entry also sends DUML **`0x02/0x68`** payload `08` (AE Lock Status Set, same bytes as the tap-focus hint) **immediately before** `0x09/0xa8`. Mimo `mimo-disconnect-20260822-105228`: first live after gallery is `0x68` then an `0xa8` burst then a 137 B VPS (NAL 32/33/34). Return-from-gallery on the same 5-tuple can skip `0x68` and still start on VPS. There is **no** live-stop command — Disconnect leaves the last GOP running, which is why handshake can see leftover TRAIL P-frames (`nals=1,35,40`) before enable. Nano has no captured `0x68` pair. Clients must keep ingesting pktType `0x02` while the library or settings cover the monitor — dropping those packets blacks the well on return (no periodic GOP). The live present surface must stay attached under that overlay too: Android API 34+ SurfaceView otherwise destroys the window when it is covered, and leftover GOP packets are not a replacement picture.

--- a/handbook/src/content/docs/protocol/wifi.md
+++ b/handbook/src/content/docs/protocol/wifi.md
@@ -31,6 +31,8 @@ On iOS this is `NEHotspotConfiguration` (Hotspot Configuration entitlement). See
 
 The UDP 9004 socket is connected to `192.168.2.1:9004`. iOS sets `NWParameters.requiredLocalEndpoint` to the phone's camera DHCP IPv4 (`192.168.2.2…254`) with an **ephemeral local port** because Network.framework `.wifi` is home `en0`. Android pins the **process** with `bindProcessToNetwork`, then `Network.bindSocket` on an unbound datagram and binds `0.0.0.0:0`. Camera 9004 is the remote — a local `:9004` bind accepted handshake + telemetry and dropped HEVC. Hopping onto home Wi-Fi after SoftAP `onLost` is the process unbind, not the wildcard bind. On Android, `onLost` is a Network-object replace for several seconds (Samsung often swaps the object after join). Handshake miss in that window rebinds UDP. After the camera path is gone, the session retries or returns to pairing — it must not crash.
 
+Live view on that socket is unicast to the associated phone. The camera does not multicast HEVC/AVC on the SoftAP ([live view](../live-view/)). Android process-bind also means a future watcher relay cannot inherit the process default — it would need a socket on a different `Network`.
+
 ### When the join fails
 
 `NEHotspotConfiguration.apply` returning no error means the configuration was applied, not that the phone associated. A wrong passphrase still returns success there; iOS shows **Unable to join the network** and `192.168.2.x` never appears. Both shells treat "no camera address within 15 s" as the join failure.


### PR DESCRIPTION
Closes #86. Product thread: discussion #53.

**Spike only.** No Sharing UI.

## Verdict

| Path | Call |
| --- | --- |
| Camera SoftAP multicast / multi-client live | **won't-do** |
| Phone-as-encoder watcher relay | Follow-on; Sharing tab stays parked |
| Keep 1:1 | **Yes** |

Live HEVC/AVC is unicast UDP on one 5-tuple (`192.168.2.1:9004` → the associated phone). Three gitignored takes (`live1.pcap`, `mimo-disconnect-20260822-105228.pcap`, `mimo-settings-1.pcapng`) show zero multicast/IGMP from the camera. Off-SoftAP probes to `:9004` got no replies. Bonjour in those takes is the **phone** (`_djimimo._tcp.local`), not the body.

A two-STA steal-vs-duplicate capture is not in `captures/`. Do not collect it with a second `0x09/0xa8` loop — that opcode is the only PLI. Simply joining the SoftAP does not duplicate the observed flow. Whether a second handshake retargets it, creates another independent unicast flow, or is refused remains untested.

iOS keeps cellular as the default route on the internetless AP; camera sockets pin Wi-Fi. Android `bindProcessToNetwork` pins the process. A later relay would re-encapsulate on another interface, not ask the camera for a second stream. No NDI/SRT in this PR.

No captures committed. Operator copy already says one phone talks to one Pocket.

Validation after merge preparation: `just check` passed (606 Swift tests), `just handbook-build` passed, and independent review confirmed the single-client evidence qualification.
