### PR TITLE
fix: allow the coffee button embed to load

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -8,7 +8,7 @@
   <meta name="description" content="OpenPocketCine is a free, open-source field-monitor app for DJI Osmo. Pocket 4P and Pocket 4 working. Pocket 3 and Nano partial. Action 5 and 6 untested.">
   <meta name="theme-color" content="#141414">
   <meta name="referrer" content="no-referrer">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-src https://tally.so; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-src https://tally.so; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
 
   <link rel="canonical" href="https://openpocketcine.app/">
   <meta property="og:type" content="website">


### PR DESCRIPTION
Allow the exact official button script in the landing page content policy so the yellow Cookie-font button renders. Verified the failing live browser check passes locally, checked the rendered button, and ran just check successfully (763 tests).