### PR TITLE
fix: center and animate the coffee button

### DIFF
--- a/site/assets/app.css
+++ b/site/assets/app.css
@@ -129,6 +129,9 @@ h3 { font-size: clamp(20px, 2.2vw, 24px); line-height: 1.25; letter-spacing: -0.
   border-radius: 8px;
   border: none;
   cursor: pointer;
+}
+.btn,
+.coffee-cta .bmc-btn {
   transition: background .2s ease, color .2s ease, border-color .2s ease, transform .2s var(--ease-out);
   transform: translate(var(--tx, 0), var(--ty, 0));
 }
@@ -760,6 +763,24 @@ h3 { font-size: clamp(20px, 2.2vw, 24px); line-height: 1.25; letter-spacing: -0.
 .cta-final { text-align: center; display: flex; flex-direction: column; align-items: center; }
 .cta-final h2 { margin-bottom: 12px; }
 .cta-final .hero__cta { margin-top: 24px; }
+
+.coffee-cta {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  margin-top: 32px;
+}
+.coffee-cta .bmc-btn {
+  justify-content: center;
+  min-width: 0;
+  height: 52px;
+  padding: 0 20px;
+  border-radius: 10px;
+  font-size: 24px;
+}
+.coffee-cta .bmc-btn-text { width: auto; }
+.coffee-cta .bmc-btn:hover,
+.coffee-cta .bmc-btn:focus-visible { background-color: #ebcc00 !important; }
 
 .beta-dialog {
   width: min(calc(100% - 32px), 480px);

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -86,7 +86,7 @@
   // ---- Magnetic buttons: pills lean toward the cursor, spring back on leave ----
   function initMagnetic() {
     if (reduceMotion || !finePointer) return;
-    document.querySelectorAll(".btn--magnetic").forEach((btn) => {
+    document.querySelectorAll(".btn--magnetic, .coffee-cta .bmc-btn").forEach((btn) => {
       const strength = 0.22, limit = 9;
       btn.addEventListener("pointermove", (e) => {
         const r = btn.getBoundingClientRect();

--- a/site/index.html
+++ b/site/index.html
@@ -347,7 +347,7 @@
           <a class="btn btn--ghost" href="https://github.com/erik-sutton95/OpenPocketCine" target="_blank" rel="noopener">★ Star on GitHub</a>
           <a class="btn btn--ghost btn--magnetic" href="https://tally.so/r/xX8eek" data-android-beta>Join Android beta</a>
         </div>
-        <div class="hero__cta" style="margin-top: 2rem;">
+        <div class="coffee-cta">
           <script type="text/javascript" src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js" data-name="bmc-button" data-slug="eriksutton" data-color="#FFDD00" data-emoji="☕" data-font="Cookie" data-text="Buy me a coffee" data-outline-color="#000000" data-font-color="#000000" data-coffee-color="#ffffff"></script>
         </div>
       </div>


### PR DESCRIPTION
Center the coffee button at every screen size, reduce its height from 60px to 52px, and reuse the Join TestFlight hover movement and transition. Verified desktop and 320px/390px layouts, matching animation values, and just check (763 tests).