### PR TITLE
fix: refresh cached homepage styles and animations

### DIFF
--- a/scripts/check-site.sh
+++ b/scripts/check-site.sh
@@ -28,6 +28,7 @@ missing=0
 for html in "${html_files[@]}"; do
   while IFS= read -r ref; do
     [[ -z "$ref" ]] && continue
+    ref="${ref%%[?#]*}"
     resolved="$(dirname "$html")/$ref"
     if [[ ! -f "$resolved" ]]; then
       echo "Missing public-site asset referenced by $html: $ref" >&2
@@ -47,6 +48,15 @@ for html in "${html_files[@]}"; do
   fi
 done
 if (( missing != 0 )); then exit 1; fi
+
+# Changed homepage assets need new URLs so cached CSS/JS cannot lag behind HTML.
+for asset in app.css app.js; do
+  version=$(shasum -a 256 "site/assets/$asset" | cut -c1-12)
+  if ! grep -Fq "assets/$asset?v=$version\"" site/index.html; then
+    echo "Update the homepage asset URL to assets/$asset?v=$version" >&2
+    exit 1
+  fi
+done
 
 external_scripts=$(grep -c '<script src="https://' site/index.html || true)
 integrity_attributes=$(grep -c 'integrity="sha384-' site/index.html || true)

--- a/site/assets/README.md
+++ b/site/assets/README.md
@@ -3,6 +3,11 @@
 Deploy-ready assets only. Raw plates, phone frames, and compositor scratch
 belong under `/tmp` or a gitignored `.local/marketing/` tree — not in `site/`.
 
+The homepage versions `app.css` and `app.js` URLs with the first 12 characters of
+each file's SHA-256 hash. After editing either file, update its `?v=` value in
+`site/index.html`; `just site-check` prints the required URL. This keeps cached
+styles and animation code in sync with the page.
+
 - `icon.png` is the OpenPocketCine mark: a production monitor on DJI Black.
 - `screens/*.webp` are the landing-page mockups and Osmo product stills loaded by `site/index.html`.
 - `frameio.png` is an identification lockup for Frame.io upload copy. Frame.io is

--- a/site/index.html
+++ b/site/index.html
@@ -26,7 +26,7 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&family=Sora:wght@500;600;700&display=swap" rel="stylesheet">
 
   <link rel="preload" as="image" href="assets/screens/hero-monitor.webp">
-  <link rel="stylesheet" href="assets/app.css">
+  <link rel="stylesheet" href="assets/app.css?v=65b6cd24b683">
 </head>
 <body>
 
@@ -403,6 +403,6 @@
   <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/ScrollTrigger.min.js"
     integrity="sha384-Z3REaz79l2IaAZqJsSABtTbhjgOUYyV3p90XNnAPCSHg3EMTz1fouunq9WZRtj3d"
     crossorigin="anonymous"></script>
-  <script src="assets/app.js" defer></script>
+  <script src="assets/app.js?v=4b0218187c1c" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Version homepage CSS and JavaScript URLs so browsers cannot combine the updated coffee button markup with cached styling and animation code. Reproduced the 60px button, zero spacing, and missing animation with a warm cache; verified the versioned URLs restore 52px sizing, 32px spacing, centering, and matching pointer movement. Site checks reject stale version hashes. just check passed (763 tests).