### PR TITLE
fix: align the final buttons on one center line

### DIFF
--- a/site/assets/app.css
+++ b/site/assets/app.css
@@ -762,7 +762,14 @@ h3 { font-size: clamp(20px, 2.2vw, 24px); line-height: 1.25; letter-spacing: -0.
 
 .cta-final { text-align: center; display: flex; flex-direction: column; align-items: center; }
 .cta-final h2 { margin-bottom: 12px; }
-.cta-final .hero__cta { margin-top: 24px; }
+.cta-final .hero__cta {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  margin-top: 24px;
+}
+@media (max-width: 560px) {
+  .cta-final .hero__cta { grid-template-columns: 1fr; }
+}
 
 .coffee-cta {
   display: flex;

--- a/site/index.html
+++ b/site/index.html
@@ -26,7 +26,7 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&family=Sora:wght@500;600;700&display=swap" rel="stylesheet">
 
   <link rel="preload" as="image" href="assets/screens/hero-monitor.webp">
-  <link rel="stylesheet" href="assets/app.css?v=65b6cd24b683">
+  <link rel="stylesheet" href="assets/app.css?v=4e8ef96dbe03">
 </head>
 <body>
 


### PR DESCRIPTION
Use equal-width columns for the final CTA row so the middle GitHub button, heading, and coffee button share the same center line. Preserve the single-column mobile layout and existing coffee spacing and animation. Verified alignment at 1200px, 600px, 390px, and 320px; just check passed (763 tests).