### PR TITLE
fix: retain portrait resolution in empty format picker

### DIFF
--- a/Apps/Android/Play/WhatToTest.en-US.txt
+++ b/Apps/Android/Play/WhatToTest.en-US.txt
@@ -1,5 +1,14 @@
-New features
+New and changed
 
-- Experimental Motion Control: plan timed A→B or A→B→C gimbal moves with smoothing, a start countdown, and Pause/Resume/Stop.
-- New false-color choices: CineStop, EL Zone and six-zone IRE.
-- ND assist suggests filter strength in a compact chip. Hold-drag to move it and choose Stops, ND32 or ND 0.3 readouts.
+- FORMAT keeps the camera's current recording size visible while its format options load.
+
+Fixes
+
+- Vertical 3K is no longer replaced by the generic 1080p and 4K choices when format options are unavailable.
+- Changing frame rate keeps the selected portrait recording size.
+
+What to test
+
+- Set a Pocket 3 to vertical 3K, connect, and open FORMAT. Confirm that 3K is shown.
+- Change the frame rate and confirm that the recording format stays 3K 9:16.
+- Return the camera to landscape recording and check that FORMAT shows its landscape choices.

--- a/Apps/Android/Play/whatsnew/whatsnew-en-US
+++ b/Apps/Android/Play/whatsnew/whatsnew-en-US
@@ -1,1 +1,1 @@
-Experimental Motion Control adds timed A→B→C gimbal moves, smoothing, countdown and Pause/Resume/Stop. New false-color choices: CineStop, EL Zone and six-zone IRE. ND assist adds a movable chip with Stops, ND32 and ND 0.3 readouts.
+FORMAT now keeps the current portrait or square recording size visible when format options are unavailable. Vertical 3K stays selected when changing frame rate.

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/session/VideoFormat.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openpocketcine/session/VideoFormat.kt
@@ -218,13 +218,17 @@ data class VideoFormat(val resolution: VideoResolution, val frameRate: VideoFram
             VideoResolution.P1080_9X16, VideoResolution.P2_7K_9X16, VideoResolution.P3K_9X16,
         ).flatMap { res -> VideoFrameRate.labeledVideo.map { rate -> VideoFormat(res, rate) } }
 
-        /** iOS `CamCapVideoFormat.resolutions`. Empty camcap → 1080 / 4K tabs. */
+        /** iOS `CamCapVideoFormat.resolutions`. Preserve a reported size when camcap is empty. */
         fun resolutions(
             available: List<VideoFormat>,
             current: VideoResolution?,
             aspect: VideoAspect? = null,
         ): List<VideoResolution> {
-            if (available.isEmpty()) return VideoResolution.labeledVideo
+            if (available.isEmpty()) {
+                val fallback = VideoResolution.labeledVideo
+                val resolutions = if (current != null && current !in fallback) listOf(current) else fallback
+                return resolutions.filter { aspect == null || it.aspect == aspect }
+            }
             val out = ArrayList<VideoResolution>()
             val seen = HashSet<VideoResolution>()
             for (format in available) {

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openpocketcine/CaptureSheetTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openpocketcine/CaptureSheetTest.kt
@@ -16,6 +16,20 @@ import kotlin.test.assertTrue
 
 class CaptureSheetTest {
     @Test
+    fun formatPickerKeepsPortraitWhenCapabilitiesHaveNotArrived() {
+        val status = CameraStatus(resolutionCode = 0x6C, fpsIndex = 2, fps = 25)
+        assertEquals(
+            listOf("3K"),
+            CaptureLists.modeTabs(LiveSheet.FORMAT, status, offersIsoAuto = false),
+        )
+        assertEquals(
+            VideoFormat(VideoResolution.P3K_9X16, VideoFrameRate.FPS30),
+            CaptureLists.nextVideoFormat(status, tab = 0, drum = "30p", fromDrum = true),
+            "changing fps must keep the reported portrait resolution",
+        )
+    }
+
+    @Test
     fun shutterWheelUsesCameraListNotHardcoded24pTable() {
         val status =
             CameraStatus(

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openpocketcine/session/CameraControlTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openpocketcine/session/CameraControlTest.kt
@@ -10,6 +10,31 @@ import kotlin.test.assertTrue
 
 class CameraControlTest {
     @Test
+    fun emptyCapabilityPortraitKeepsReportedResolution() {
+        val current = VideoFormat(VideoResolution.P3K_9X16, VideoFrameRate.FPS25)
+        val formats = VideoFormat.pickerFormats(emptyList(), CameraModel("Osmo Pocket 3"), -1)
+        val aspects = VideoFormat.aspects(formats, current.resolution.aspect)
+        val resolutions = VideoFormat.resolutions(
+            formats, current.resolution,
+            if (aspects.size > 1) VideoAspect.NINE_SIXTEEN else null,
+        )
+        assertEquals(listOf(VideoResolution.P3K_9X16), resolutions)
+        assertEquals(listOf("3K"), resolutions.map { it.tabTitle })
+    }
+
+    @Test
+    fun emptyCapabilityPreservesReportedSizesWithoutInventingAnAspect() {
+        for (current in listOf(
+            VideoResolution.P3K_1X1, VideoResolution.P2_7K,
+            VideoResolution.P4K_4X3, VideoResolution(0xFE),
+        )) {
+            assertEquals(listOf(current), VideoFormat.resolutions(emptyList(), current))
+        }
+        assertEquals(listOf(VideoResolution.P1080, VideoResolution.P4K), VideoFormat.resolutions(emptyList(), null))
+        assertTrue(VideoFormat.resolutions(emptyList(), VideoResolution.P3K_9X16, VideoAspect.SIXTEEN_NINE).isEmpty())
+    }
+
+    @Test
     fun pocket3PickerFallbackIncludesNormalVideoSizesOnly() {
         val model = CameraModel(name = "Osmo Pocket 3")
         val formats = VideoFormat.pickerFormats(emptyList(), model, CameraCommands.SHOOT_VIDEO)

--- a/Sources/OpenPocketViewCore/CamCap.swift
+++ b/Sources/OpenPocketViewCore/CamCap.swift
@@ -289,7 +289,12 @@ public enum CamCapVideoFormat {
         available: [VideoFormat], aspect: VideoAspect?, current: VideoResolution?
     ) -> [VideoResolution] {
         if available.isEmpty {
-            return VideoResolution.labeledVideo
+            // Status can arrive before the model/mode enables its picker fallback.
+            // Keep a reported portrait, square or unknown size instead of selecting
+            // the first landscape tab and sending that size on an fps change.
+            let fallback = VideoResolution.labeledVideo
+            let resolutions = current.map { fallback.contains($0) ? fallback : [$0] } ?? fallback
+            return resolutions.filter { aspect == nil || $0.aspect == aspect }
         }
         var seen = Set<VideoResolution>()
         var out: [VideoResolution] = []

--- a/Tests/OpenPocketViewCoreTests/CamCapTests.swift
+++ b/Tests/OpenPocketViewCoreTests/CamCapTests.swift
@@ -3,6 +3,32 @@ import Testing
 @testable import OpenPocketViewCore
 
 @Suite struct CamCapTests {
+    @Test func emptyCapabilityPortraitKeepsReportedResolution() {
+        let statusFormat = VideoFormat(resolution: .p3K_9x16, frameRate: .fps25)
+        let formats = CamCapVideoFormat.pickerFormats(
+            available: [], model: CameraModel.resolve(modelId: 0x20, name: nil),
+            shootingMode: -1)
+        let aspects = CamCapVideoFormat.aspects(
+            available: formats, current: statusFormat.resolution.aspect)
+        let resolutions = CamCapVideoFormat.resolutions(
+            available: formats, aspect: aspects.count > 1 ? .nineSixteen : nil,
+            current: statusFormat.resolution)
+        #expect(resolutions == [.p3K_9x16])
+        #expect(resolutions.map(\.tabTitle) == ["3K"])
+    }
+
+    @Test func emptyCapabilityPreservesReportedSizesWithoutInventingAnAspect() {
+        for current in [VideoResolution.p3K_1x1, .p2_7K, .p4K_4x3, .init(rawValue: 0xFE)] {
+            #expect(CamCapVideoFormat.resolutions(available: [], current: current) == [current])
+        }
+        #expect(CamCapVideoFormat.resolutions(available: [], current: nil) == [.p1080, .p4K])
+        #expect(CamCapVideoFormat.resolutions(available: [], current: .p4K) == [.p1080, .p4K])
+        #expect(
+            CamCapVideoFormat.resolutions(
+                available: [], aspect: .sixteenNine, current: .p3K_9x16
+            ).isEmpty)
+    }
+
     @Test func pocket3PickerIncludesDocumentedFormatsWithoutCapabilities() {
         let model = CameraModel.resolve(modelId: 0x20, name: "OsmoPocket3-Test")
         let formats = CamCapVideoFormat.pickerFormats(available: [], model: model, shootingMode: 1)

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -261,6 +261,22 @@ livestream retain their existing handling. This is a picker fallback; it does
 not rewrite reported camera capabilities. Synthetic picker tests cover model and
 mode isolation. Physical format SET/reconnect verification is pending.
 
+### FORMAT retains the reported size while capabilities are unavailable
+
+Both shells keep a reported portrait, square, 2.7K or unknown resolution visible
+when the effective format list is empty. For example, a reported `3K 9:16`
+shows a `3K` tab, and changing fps keeps its portrait resolution byte. The
+legacy 1080/4K tabs remain when no current size has been reported or the size
+is already one of those two landscape sizes. Reported capabilities and the
+confirmed Pocket 3 normal-Video matrix still take precedence.
+
+Core and Android picker regressions cover this behavior, including retaining the
+portrait resolution when changing fps. After installing the correction on an
+iPhone 16 Pro Max on 2026-09-11, the operator confirmed that the vertical 3K
+picker worked. Physical Android verification and an on-camera fps-change check
+remain pending. The reproduction does not establish why the operator's earlier
+session had an empty format list.
+
 ### Log conversion export (iOS)
 
 Share **Convert log** chooses one **Output curve** (D-Log or D-Log2) for the

--- a/docs/osmo-recording-formats.md
+++ b/docs/osmo-recording-formats.md
@@ -126,12 +126,20 @@ Shooting mode (`0x02/0xE1`, sparse — never sweep):
 
 ## What the FORMAT sheet does today
 
-iOS `CaptureControlSheets` / Android `CaptureLists` build tabs from
-`CamCapVideoFormat.resolutions`. Empty camcap falls back to 1080 / 4K and
-24–60. Tests assert `2.7K` is **not** a tab.
+iOS `CaptureControlSheets` and Android `CaptureLists` build tabs from the
+effective format list: camera-reported pairs take precedence, followed by the
+documented Pocket 3 normal-Video fallback when the model and mode are known.
+The parser retains additional and unknown resolution bytes; known aspects group
+the size choices. An fps change selects a pair for that resolution.
 
-So even if a Nano camcap lists `0x2D` / `0x67`, the parser throws them away
-and the operator only sees 1080 and 4K.
+When the effective list is empty, both shells preserve a reported size outside
+the legacy 1080/4K pair as the sole resolution tab. Thus `3K 9:16` stays `3K`,
+and an fps change retains its resolution byte. The generic 1080/4K tabs still
+apply when no size has been reported or it is already one of those two.
+This does not expand the legal format matrix. Core and Android picker tests
+cover the fallback and retaining portrait on an fps change. The operator
+confirmed the corrected vertical 3K picker on a physical iPhone on 2026-09-11;
+Android and on-camera fps-change verification remain pending.
 
 ## Pocket-line aspects (why Nano and Pocket 3 look “richer”)
 

--- a/handbook/src/content/docs/protocol/commands.md
+++ b/handbook/src/content/docs/protocol/commands.md
@@ -60,3 +60,12 @@ when the capability table is empty: 1080p/2.7K/4K in 16:9, 1080p/2160p/3K in 1:1
 and 1080p/2.7K/3K in 9:16, at 24/25/30/48/50/60 fps. Camera-reported tables take
 precedence. This fallback is not applied to SlowMo, livestream or an unknown
 shooting mode. Existing `02/18` SET and camera-status confirmation are used.
+
+When the effective format list is still empty, the picker retains a known current
+size such as **3K 9:16** rather than replacing it with the generic 1080p/4K
+landscape choices. Changing fps retains that resolution. This preserves the
+reported value without inventing additional portrait formats; the full Pocket 3
+list above still requires a confirmed model and normal Video mode. The change
+has automated coverage on both platforms. The operator confirmed the corrected
+vertical 3K picker on an iPhone on 2026-09-11; Android and on-camera fps-change
+verification remain pending.

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,8 +1,14 @@
-New features
+New and changed
 
-- Experimental Multiview: monitor multiple Osmo cameras on shared Wi-Fi, save camera stages, choose grid or Center stage layouts, and record individually or together.
-- Share this feed with other OpenPocketCine iPhones and iPads on the same camera Wi-Fi. Watchers get their own assists and scopes, with camera controls when the host grants access.
-- Experimental Motion Control: plan timed A→B or A→B→C gimbal moves with smoothing, a start countdown, and Pause/Resume/Stop.
-- New false-color choices: CineStop, EL Zone and six-zone IRE.
-- ND assist suggests filter strength in a compact chip. Hold-drag to move it and choose Stops, ND32 or ND 0.3 readouts.
-- Convert log lets you choose D-Log or D-Log2 for a selection of cached log clips, while keeping camera originals.
+- FORMAT keeps the camera's current recording size visible while its format options load.
+
+Fixes
+
+- Vertical 3K is no longer replaced by the generic 1080p and 4K choices when format options are unavailable.
+- Changing frame rate keeps the selected portrait recording size.
+
+What to test
+
+- Set a Pocket 3 to vertical 3K, connect, and open FORMAT. Confirm that 3K is shown.
+- Change the frame rate and confirm that the recording format stays 3K 9:16.
+- Return the camera to landscape recording and check that FORMAT shows its landscape choices.


### PR DESCRIPTION
## What & why

When the camera reports `3K 9:16` while the effective format list is empty, FORMAT used to replace it with the generic 1080p/4K tabs. Changing fps could then select a landscape resolution. Preserve the reported nonstandard size as the current tab in the shared Swift policy and Android mirror. Reported capability tables and the existing Pocket 3 normal-Video matrix keep precedence.

Regression tests cover the reproduced missing-3K case, square/2.7K/unknown bytes, aspect isolation, and Android's actual picker-to-fps-selection path. Update the handbook and parity notes with the behavior and verification limits.

Validation: `just check` (765 core tests), `just native-check`, `ANDROID_HOME=/opt/homebrew/share/android-commandlinetools just android-check`, and `just handbook-build` pass. Separate-context review passes. The updated app was installed and launched on an iPhone 16 Pro Max; the operator confirmed the vertical 3K picker works.

Draft pending physical Android and on-camera fps-change verification. The synthetic reproduction establishes the empty-list bug, but does not establish why the operator's earlier session had an empty effective list. This branch is independent of the larger Pocket 3 reference survey in #328.

## TestFlight notes

Updated TestFlight and Play notes describe the portrait-format correction and checks for 3K display, fps changes and returning to landscape.

## Checklist

- [x] `just check`, `just native-check` and `just android-check` pass locally.
- [x] Conventional Commits, repository hygiene and secret checks pass.
- [x] Handbook and parity documentation updated.
- [x] TestFlight and Play notes updated and validated.
- [x] Physical iPhone picker confirmed by the operator.
- [ ] Physical Android and on-camera fps-change verification.
