### PR TITLE
docs: keep tester notes to a this-build window

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,17 +2,16 @@
 
 <!-- What does this PR change, and why? Link any related issue. -->
 
-## TestFlight notes
+## Tester notes
 
 <!--
-If this PR changes Sources/, Tests/, ios/, Package.swift, scripts/, or justfile, replace
-ios/TestFlight/WhatToTest.en-US.txt. For a feature summary, use:
-- New features (1-6 bullets; new app capabilities only)
-For detailed tester notes, use all three sections:
-- New and changed (1-6 bullets)
-- Fixes (1-8 bullets)
-- What to test (1-5 concrete actions)
-Write for camera operators. For a build with no tester-facing app behavior, say that plainly.
+If this PR can trigger a TestFlight or Play build, replace WhatToTest (and
+Android whatsnew) with the this-build window: this PR plus up to three other
+newest operator-visible feat/fix items this platform can see.
+Run `just tester-notes-window`. See docs/tester-notes.md.
+- New features (1-4) for a capability-only window
+- Or New and changed (1-3) / Fixes (1-4) / What to test (1-3)
+CHANGELOG.md stays cumulative. For a build with no tester-facing behavior, say that.
 -->
 
 ## Checklist
@@ -22,5 +21,5 @@ Write for camera operators. For a build with no tester-facing app behavior, say 
 - [ ] Commits follow Conventional Commits.
 - [ ] No captures, Wi-Fi passwords, unofficial LUT dumps, signing material, or other secrets.
 - [ ] Docs/CHANGELOG updated if behavior or setup changed. Public handbook pages updated when protocol, app, or setup visitors read has changed.
-- [ ] TestFlight-triggering changes include reviewed `ios/TestFlight/WhatToTest.en-US.txt` copy.
+- [ ] TestFlight- or Play-triggering changes replace WhatToTest with the this-build window (`docs/tester-notes.md`).
 - [ ] iOS release PRs: bump `MARKETING_VERSION` in `ios/Config/Version.xcconfig` when starting a new version train.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,12 @@ jobs:
           # write notes fails here.
           # Combined merge diffs also count notes rewritten during conflict resolution.
           changed_files="$(git log --diff-merges=combined --format= --name-only "$BASE_SHA..HEAD" | sort -u)"
-          if grep -Eq '^(Sources/|Tests/|ios/|Package\.swift$|scripts/ios-|scripts/setup-xcode-cloud\.sh$)' <<< "$changed_files"; then
+          # Notes-check tooling is not a TestFlight archive. Require copy only when
+          # production iOS paths change (docs/tester-notes.md).
+          production_files="$(grep -E '^(Sources/|Tests/|ios/|Package\.swift$|scripts/ios-|scripts/setup-xcode-cloud\.sh$)' <<< "$changed_files" | grep -vE '^scripts/ios-release-notes' || true)"
+          if [[ -n "$production_files" ]]; then
             if ! grep -Fxq 'ios/TestFlight/WhatToTest.en-US.txt' <<< "$changed_files"; then
-              echo "Update ios/TestFlight/WhatToTest.en-US.txt with plain-language changes and test steps." >&2
+              echo "Update ios/TestFlight/WhatToTest.en-US.txt with the this-build window (docs/tester-notes.md)." >&2
               exit 1
             fi
           fi
@@ -93,9 +96,12 @@ jobs:
           # write notes fails here.
           # Combined merge diffs also count notes rewritten during conflict resolution.
           changed_files="$(git log --diff-merges=combined --format= --name-only "$BASE_SHA..HEAD" | sort -u)"
-          if grep -Eq '^(Apps/Android/|Sources/OpenPocketViewCore/|Sources/OpenPocketCineAndroidFacade/|Sources/CJNI/|Package\.swift$|scripts/android-|scripts/ci-install-swift-android\.sh$)' <<< "$changed_files"; then
+          # Notes-check tooling is not a Play upload. Require copy only when
+          # production Android paths change (docs/tester-notes.md).
+          production_files="$(grep -E '^(Apps/Android/|Sources/OpenPocketViewCore/|Sources/OpenPocketCineAndroidFacade/|Sources/CJNI/|Package\.swift$|scripts/android-|scripts/ci-install-swift-android\.sh$)' <<< "$changed_files" | grep -vE '^scripts/android-release-notes' || true)"
+          if [[ -n "$production_files" ]]; then
             if ! grep -Fxq 'Apps/Android/Play/WhatToTest.en-US.txt' <<< "$changed_files"; then
-              echo "Update Apps/Android/Play/WhatToTest.en-US.txt with plain-language changes and test steps." >&2
+              echo "Update Apps/Android/Play/WhatToTest.en-US.txt with the this-build window (docs/tester-notes.md)." >&2
               exit 1
             fi
             if ! grep -Fxq 'Apps/Android/Play/whatsnew/whatsnew-en-US' <<< "$changed_files"; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ primarily **Osmo Pocket 4 / 4 Pro**, with Nano live view on AVC.
 - **ux** — FTUE, first-run, wizard, operator copy, help, empty/error: [`docs/UX.md`](docs/UX.md)
 - **workflow** — parallel, subagent, loop, verify in a fresh context, graphify: [`docs/WORKFLOW.md`](docs/WORKFLOW.md)
 - **release** — tag, version bump, TestFlight train, `develop` / Git Flow: [`docs/RELEASE.md`](docs/RELEASE.md)
+- **tester-notes** — TestFlight / Play What to Test, this-build window: [`docs/tester-notes.md`](docs/tester-notes.md)
 - **play** — Android closed testing, AAB upload, Play CI: [`docs/android-play-ci.md`](docs/android-play-ci.md)
 
 ## Verification

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,13 +53,14 @@ GitHub-specific:
   Swift/iOS, Android, and the protocol handbook feed that gate and skip when
   their paths did not change). The PR template must be filled in. Maintainer
   GitHub settings: [`docs/repository-settings.md`](docs/repository-settings.md).
-- Changes that can trigger a TestFlight build must update
-  [`ios/TestFlight/WhatToTest.en-US.txt`](ios/TestFlight/WhatToTest.en-US.txt). See
-  [`docs/testflight-ci.md`](docs/testflight-ci.md).
-- Changes that can trigger a Play closed-testing upload must update
+- Changes that can trigger a TestFlight build must **replace**
+  [`ios/TestFlight/WhatToTest.en-US.txt`](ios/TestFlight/WhatToTest.en-US.txt)
+  with the this-build window (`just tester-notes-window`). See
+  [`docs/tester-notes.md`](docs/tester-notes.md).
+- Changes that can trigger a Play closed-testing upload must **replace**
   [`Apps/Android/Play/WhatToTest.en-US.txt`](Apps/Android/Play/WhatToTest.en-US.txt)
-  and the 500-character [`whatsnew-en-US`](Apps/Android/Play/whatsnew/whatsnew-en-US).
-  See [`docs/android-play-ci.md`](docs/android-play-ci.md).
+  and the 500-character [`whatsnew-en-US`](Apps/Android/Play/whatsnew/whatsnew-en-US)
+  the same way. See [`docs/tester-notes.md`](docs/tester-notes.md).
 
 ## Code standards
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -62,7 +62,8 @@ git push origin v0.2.0
 ```
 
 Then a GitHub Release from that tag. Changelog: move `[Unreleased]` entries under
-`## [0.2.0] - YYYY-MM-DD` in the same version-bump PR.
+`## [0.2.0] - YYYY-MM-DD` in the same version-bump PR. TestFlight and Play tester
+notes are a this-build window, not that changelog — [`tester-notes.md`](tester-notes.md).
 
 One tag for both platforms (`v0.2.0`). Do not cut `ios/0.2.0` and `android/0.2.0`
 unless the apps actually ship different product versions — they share the Swift

--- a/docs/UX.md
+++ b/docs/UX.md
@@ -76,8 +76,7 @@ Link health in the top bar is delivery (FPS chip), not RSSI.
   tally around the picture. Request/Release control stays on the monitor; camera
   controls appear only with the host grant. Interrupted feeds hold the last frame,
   show bounded reconnect progress, and retain Leave / Choose a feed after failure.
-- TestFlight “What to Test” is operator copy (`docs/testflight-ci.md`).
-- Play closed-testing notes are the same voice (`docs/android-play-ci.md`).
+- TestFlight / Play What to Test is this-build operator copy (`docs/tester-notes.md`).
 - Connection setup (first pair): **Share Diagnostics** on the wizard so a
   tester who never reaches Operator Setup can still send a report.
 - Operator Setup → System → **Share Diagnostics**. iOS screenshot for

--- a/docs/android-play-ci.md
+++ b/docs/android-play-ci.md
@@ -116,55 +116,23 @@ just android-play-dispatch
 
 ## Tester-facing release notes
 
-Play listing "what's new" is 500 characters. The longer What to Test file is
-operator copy for GitHub / email, same shape as TestFlight.
+**this-build** window, same contract as TestFlight:
+[`tester-notes.md`](tester-notes.md). Play listing "what's new" is 500
+characters. The longer What to Test file is operator copy for GitHub / email.
 
-Any pull request that can trigger a Play upload must replace
-`Apps/Android/Play/WhatToTest.en-US.txt` **and** the 500-character
-`whatsnew-en-US`. For a feature summary, use **New features** with 1-6 bullets.
-Include only new Android capabilities in the release window; omit fixes,
-maintenance and test instructions. Keep the Play paragraph focused on the same
-features and within its 500-character limit:
+Any pull request that can trigger a Play upload replaces
+`Apps/Android/Play/WhatToTest.en-US.txt` **and** `whatsnew-en-US` with this
+PR plus up to three other newest operator-visible `feat:` / `fix:` items
+Android testers can see.
 
-```text
-New features
-
-- ND assist suggests a filter strength to help balance exposure.
+```bash
+just tester-notes-window
+just android-play-notes
 ```
-
-For detailed tester notes, use all three sections in this order:
-
-```text
-New and changed
-
-- Pair over Bluetooth, join the camera's Wi-Fi, and watch a live view with waveform and assists.
-
-Fixes
-
-- Nothing to call out yet — this is the first closed-beta build.
-
-What to test
-
-- Pair an Osmo Pocket 4 Pro, join its Wi-Fi, and confirm live view fills the monitor.
-```
-
-Write for camera operators:
-
-- Include only behavior visible in the Android app.
-- Say what changed for the tester, not how it was implemented.
-- Use the names testers see in the app.
-- Keep **New and changed** to 1-6 bullets, **Fixes** to 1-8, **What to test** to 1-5 concrete actions.
-- Exclude iPhone, TestFlight, website, CI, architecture, identifiers, issue numbers, and source-file details.
 
 `scripts/android-release-notes-check.sh` enforces the format. Pull-request CI
 also verifies that the notes files changed when Android production paths
 changed.
-
-Preview locally:
-
-```bash
-just android-play-notes
-```
 
 ## Version numbers
 

--- a/docs/tester-notes.md
+++ b/docs/tester-notes.md
@@ -1,0 +1,95 @@
+# Tester notes (this-build window)
+
+TestFlight and Play What to Test is **this-build**: the operator-visible
+work testers have not already been asked to try. It is not a product recap
+and not `CHANGELOG.md`. Testers who skip a build still have the app.
+
+`CHANGELOG.md` stays the cumulative record. GitHub Release notes come from
+that file at a `v*` tag ([`RELEASE.md`](RELEASE.md)).
+
+## Files
+
+| Platform | Longer notes | Store short copy |
+| --- | --- | --- |
+| iOS TestFlight | [`ios/TestFlight/WhatToTest.en-US.txt`](../ios/TestFlight/WhatToTest.en-US.txt) | (TestFlight uses the same file) |
+| Android Play | [`Apps/Android/Play/WhatToTest.en-US.txt`](../Apps/Android/Play/WhatToTest.en-US.txt) | [`whatsnew-en-US`](../Apps/Android/Play/whatsnew/whatsnew-en-US) (500 characters) |
+
+Any pull request that can trigger a TestFlight archive or a Play upload
+**replaces** those files. CI requires the path to change; this document
+requires the *content* to be the window, not an append.
+
+## Steps
+
+1. Run `just tester-notes-window`. Completion: the printed list is this PR's
+   `feat:` / `fix:` commits (if any) plus the newest operator-visible merges
+   on `origin/main`.
+2. Keep **this PR first**, then fill from that list until you have about
+   **four** items this platform can actually see. Skip `build:`, `ci:`,
+   `docs:`, `chore:`, website-only work, and the other shell.
+3. Replace the whole What to Test file. Prefer **New features** when the
+   window is new capabilities only. Use the three-section form when testers
+   need a fix named or a concrete action.
+
+   **New features** (1–4 bullets):
+
+   ```text
+   New features
+
+   - ND assist suggests a filter strength to help balance exposure.
+   ```
+
+   **Detailed** (New and changed 1–3, Fixes 1–4, What to test 1–3):
+
+   ```text
+   New and changed
+
+   - FORMAT keeps the camera's current recording size visible while options load.
+
+   Fixes
+
+   - Vertical 3K is no longer replaced by generic 1080p and 4K choices.
+
+   What to test
+
+   - Set a Pocket 3 to vertical 3K, connect, and open FORMAT. Confirm 3K is shown.
+   ```
+
+   Completion: each bullet is one idea, under 200 characters. The file is
+   under 2,000 characters. A detailed section with nothing new still has
+   one bullet (`No new controls this build.` / `Nothing to call out this build.`).
+4. Android: rewrite `whatsnew-en-US` as one compact paragraph of the same
+   window (Play's 500-character cap). No tabs, no double spaces.
+5. Voice: camera operators, names they see in the app, visible behavior.
+   iOS notes name iPhone/iPad behavior only; Android notes name Android
+   behavior only.
+6. `just testflight-notes` and/or `just android-play-notes`. Completion: the
+   check scripts pass.
+
+## Window
+
+Newest first, cap four, this PR leads. That is enough for testers who
+missed one or two builds and short enough that last week's recap drops off.
+
+```bash
+just tester-notes-window
+```
+
+The helper prints this branch, then `feat:` / `fix:` on `origin/main`. It
+does not write the files.
+
+## Checks
+
+`scripts/ios-release-notes-check.sh` and
+`scripts/android-release-notes-check.sh` enforce the format and the caps.
+Pull-request CI also requires the notes path to change when production
+paths change (dependabot is exempt). Preview:
+
+```bash
+just testflight-notes
+just android-play-notes
+```
+
+## When this pointer fires
+
+TestFlight notes, Play What to Test, `whatsnew-en-US`, tester copy, or
+"what should testers try in this build."

--- a/docs/testflight-ci.md
+++ b/docs/testflight-ci.md
@@ -44,40 +44,17 @@ connects this GitHub repo, and defines the `main` Archive workflow.
 
 ## Tester-facing release notes
 
-TestFlight notes are reviewed product copy, not a git log. Any pull request that can trigger a
-TestFlight build must replace `ios/TestFlight/WhatToTest.en-US.txt`. For a feature
-summary, use **New features** with 1-6 bullets. Include only new capabilities in
-the release window; omit fixes, maintenance and test instructions:
+**this-build** window, not a product recap: [`tester-notes.md`](tester-notes.md).
+Any pull request that can trigger a TestFlight build replaces
+`ios/TestFlight/WhatToTest.en-US.txt` with this PR plus up to three other
+newest operator-visible `feat:` / `fix:` items iPhone testers can see.
+**New features** (1–4) for a capability-only window; three-section form when
+testers need a named fix or a concrete action.
 
-```text
-New features
-
-- ND assist suggests a filter strength to help balance exposure.
+```bash
+just tester-notes-window
+just testflight-notes
 ```
-
-For detailed tester notes, use all three sections in this order:
-
-```text
-New and changed
-
-- Pair over Bluetooth, join the camera's Wi-Fi, and watch a live view with waveform and assists.
-
-Fixes
-
-- Nothing to call out yet — this is the first TestFlight build.
-
-What to test
-
-- Pair an Osmo Pocket 4, join its Wi-Fi, and confirm live view fills the monitor.
-```
-
-Write for camera operators:
-
-- Include only behavior visible in the iPhone or iPad app.
-- Say what changed for the tester, not how it was implemented.
-- Use the names testers see in the app.
-- Keep **New and changed** to 1-6 bullets, **Fixes** to 1-8, **What to test** to 1-5 concrete actions.
-- Exclude Android, website, CI, architecture, identifiers, issue numbers, and source-file details.
 
 `scripts/ios-release-notes-check.sh` enforces the format. Pull-request CI also verifies that the
 notes file changed when iOS production paths changed.
@@ -88,12 +65,6 @@ when the tester screenshots; they paste it into the feedback comment.
 Crashes still go to App Store Connect automatically. Full report:
 Connection setup **Share Diagnostics**, or Operator Setup → System →
 Share Diagnostics. Contract: [`diagnostics.md`](diagnostics.md).
-
-Preview locally:
-
-```bash
-just testflight-notes
-```
 
 ## Version numbers
 

--- a/handbook/src/content/docs/apps/ios.md
+++ b/handbook/src/content/docs/apps/ios.md
@@ -151,9 +151,9 @@ Platform notes for the wire (Hotspot Configuration, Local Network, CoreBluetooth
 ## Releases
 
 Public beta: [TestFlight](https://testflight.apple.com/join/1tmt3aEB). PRs that
-change `Sources/`, `ios/`, or `Package.swift` update
-`ios/TestFlight/WhatToTest.en-US.txt` for operators. See
-[`docs/testflight-ci.md`](https://github.com/erik-sutton95/OpenPocketCine/blob/main/docs/testflight-ci.md).
+change `Sources/`, `ios/`, or `Package.swift` replace
+`ios/TestFlight/WhatToTest.en-US.txt` with the this-build window. See
+[`docs/tester-notes.md`](https://github.com/erik-sutton95/OpenPocketCine/blob/main/docs/tester-notes.md).
 
 If pairing or live view fails: Connection setup **Share Diagnostics**, or
 Operator Setup → System → **Share Diagnostics**, or take a screenshot for

--- a/handbook/src/content/docs/contribute/documentation.md
+++ b/handbook/src/content/docs/contribute/documentation.md
@@ -27,6 +27,7 @@ Gotchas that only agents need stay in `docs/live-session.md`.
 | Build, toolchain, how to run | [Setup](../guides/setup/) and `CONTRIBUTING.md` if GitHub workflow changed |
 | Git, tags, version trains | [`docs/RELEASE.md`](https://github.com/erik-sutton95/OpenPocketCine/blob/main/docs/RELEASE.md) (not Git Flow; no `develop`) |
 | Play closed testing | [`docs/android-play-ci.md`](https://github.com/erik-sutton95/OpenPocketCine/blob/main/docs/android-play-ci.md); this handbook only if the public Android install path changed |
+| TestFlight / Play tester notes | [`docs/tester-notes.md`](https://github.com/erik-sutton95/OpenPocketCine/blob/main/docs/tester-notes.md) (this-build window; not the handbook) |
 | Architecture seams (core vs shell) | [Architecture](../apps/architecture/) if the public map changed; `docs/ARCHITECTURE.md` is the seam table |
 | Live-path budgets (ACK Hz, HUD Hz) | `docs/PERFORMANCE.md` (not duplicated here) |
 | First-run / operator copy | `docs/UX.md`; handbook only if the public FTUE description changed |
@@ -37,12 +38,9 @@ Merge to `main` deploys Pages when `handbook/` or `site/` changed.
 
 ## Release notes
 
-Write release notes for camera operators and include only features available on
-the target platform. A short **New features** summary can cover a chosen set of
-merged PRs without fixes, dependency updates or test instructions. Detailed tester
-notes can also include fixes and actions to try. Formats and limits live in the
-[TestFlight notes guide](https://github.com/erik-sutton95/OpenPocketCine/blob/main/docs/testflight-ci.md#tester-facing-release-notes)
-and [Play notes guide](https://github.com/erik-sutton95/OpenPocketCine/blob/main/docs/android-play-ci.md#tester-facing-release-notes).
+Tester notes are a this-build window for camera operators, not a product recap.
+Contract: [`docs/tester-notes.md`](https://github.com/erik-sutton95/OpenPocketCine/blob/main/docs/tester-notes.md).
+This handbook does not duplicate that copy.
 
 ## One home per fact
 

--- a/justfile
+++ b/justfile
@@ -76,6 +76,10 @@ swift-test:
 # Run all Swift-only checks.
 swift-check: swift-lint swift-test
 
+# Print the this-build feat/fix window for TestFlight / Play notes.
+tester-notes-window:
+    ./scripts/tester-notes-window.sh
+
 # Validate TestFlight "What to Test" copy and print it.
 testflight-notes:
     ./scripts/ios-release-notes-check.sh

--- a/scripts/android-release-notes-check.sh
+++ b/scripts/android-release-notes-check.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
-# Validate Android closed-testing notes: operator copy plus Play's 500-character what's new.
+# Validate Android closed-testing notes: this-build window plus Play what's new.
+# Caps: scripts/tester-notes-limits.sh  Contract: docs/tester-notes.md
 set -euo pipefail
 
 notes_path="${1:-Apps/Android/Play/WhatToTest.en-US.txt}"
 whatsnew_path="${2:-Apps/Android/Play/whatsnew/whatsnew-en-US}"
-max_notes_characters=4000
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tester-notes-limits.sh
+source "${script_dir}/tester-notes-limits.sh"
 max_whatsnew_characters=500
 
 fail() {
@@ -16,8 +19,8 @@ fail() {
 [[ -f "$whatsnew_path" ]] || fail "missing ${whatsnew_path}"
 
 character_count="$(wc -m < "$notes_path" | tr -d '[:space:]')"
-if ((character_count > max_notes_characters)); then
-  fail "${notes_path} is ${character_count} characters; keep it under ${max_notes_characters}"
+if ((character_count > tester_notes_max_characters)); then
+  fail "${notes_path} is ${character_count} characters; this-build notes cap is ${tester_notes_max_characters}"
 fi
 
 whatsnew_count="$(wc -m < "$whatsnew_path" | tr -d '[:space:]')"
@@ -32,8 +35,13 @@ if grep -Eq $'[\t]|  ' "$whatsnew_path"; then
   fail "${whatsnew_path} should be a single compact paragraph for Play"
 fi
 
-# Accept the same compact feature summary or detailed tester format as TestFlight.
-if ! awk '
+# Compact "New features" or detailed three-section form. Same this-build contract as TestFlight.
+awk_status=0
+awk -v max_feat="$tester_notes_max_feature_bullets" \
+  -v max_new="$tester_notes_max_new_bullets" \
+  -v max_fix="$tester_notes_max_fix_bullets" \
+  -v max_test="$tester_notes_max_test_bullets" \
+  -v max_bullet="$tester_notes_max_bullet_characters" '
   BEGIN {
     section = 0
     new_headings = 0
@@ -44,6 +52,7 @@ if ! awk '
     fix_bullets = 0
     test_bullets = 0
     invalid = 0
+    long_bullet = 0
   }
   $0 == "New features" {
     feature_headings++
@@ -71,6 +80,8 @@ if ! awk '
   }
   /^[[:space:]]*$/ { next }
   /^- .+/ {
+    body = substr($0, 3)
+    if (length(body) > max_bullet) long_bullet = 1
     if (section == 1) new_bullets++
     else if (section == 2) fix_bullets++
     else if (section == 3) test_bullets++
@@ -79,18 +90,23 @@ if ! awk '
   }
   { invalid = 1 }
   END {
+    if (long_bullet) exit 2
     if (feature_headings > 0) {
       if (feature_headings != 1 || new_headings || fix_headings || test_headings || invalid) exit 1
-      if (new_bullets < 1 || new_bullets > 6) exit 1
+      if (new_bullets < 1 || new_bullets > max_feat) exit 1
       exit 0
     }
     if (new_headings != 1 || fix_headings != 1 || test_headings != 1 || invalid) exit 1
-    if (new_bullets < 1 || new_bullets > 6) exit 1
-    if (fix_bullets < 1 || fix_bullets > 8) exit 1
-    if (test_bullets < 1 || test_bullets > 5) exit 1
+    if (new_bullets < 1 || new_bullets > max_new) exit 1
+    if (fix_bullets < 1 || fix_bullets > max_fix) exit 1
+    if (test_bullets < 1 || test_bullets > max_test) exit 1
   }
-' "$notes_path"; then
-  fail "use 'New features' with 1-6 bullets, or 'New and changed', 'Fixes', 'What to test' with 1-6 / 1-8 / 1-5 bullets"
+' "$notes_path" || awk_status=$?
+if ((awk_status == 2)); then
+  fail "each bullet is one idea, under ${tester_notes_max_bullet_characters} characters"
+fi
+if ((awk_status != 0)); then
+  fail "use 'New features' with 1-${tester_notes_max_feature_bullets} bullets, or 'New and changed', 'Fixes', 'What to test' with 1-${tester_notes_max_new_bullets} / 1-${tester_notes_max_fix_bullets} / 1-${tester_notes_max_test_bullets} bullets"
 fi
 
 if grep -Eiq '^- (feat|fix|perf|refactor|chore|build|test|style)(\([^)]+\))?!?:' "$notes_path"; then

--- a/scripts/android-release-notes-test.sh
+++ b/scripts/android-release-notes-test.sh
@@ -66,11 +66,11 @@ for suffix in 'New features' 'New and changed' 'Fixes' 'What to test'; do
   expect_fail "${temp_dir}/mixed-features.txt"
 done
 
-for _ in {2..6}; do
+for _ in {2..4}; do
   printf '%s\n' '- Another visible feature.' >> "${temp_dir}/features.txt"
 done
 expect_pass "${temp_dir}/features.txt"
-printf '%s\n' '- A seventh feature exceeds the limit.' >> "${temp_dir}/features.txt"
+printf '%s\n' '- A fifth feature exceeds the this-build window.' >> "${temp_dir}/features.txt"
 expect_fail "${temp_dir}/features.txt"
 
 printf 'New features\n\n- Added a GUID migration.\n' > "${temp_dir}/feature-jargon.txt"
@@ -127,5 +127,25 @@ if "$validator" "${temp_dir}/valid.txt" "$too_long" >/dev/null 2>&1; then
   printf 'Expected Play whatsnew length check to fail.\n' >&2
   exit 1
 fi
+
+# this-build caps: 4 New features, 200 characters per bullet.
+cat > "${temp_dir}/five-features.txt" <<'EOF'
+New features
+
+- First visible feature.
+- Second visible feature.
+- Third visible feature.
+- Fourth visible feature.
+- Fifth visible feature.
+EOF
+expect_fail "${temp_dir}/five-features.txt"
+
+long_idea="$(python3 -c 'print("A" * 201)')"
+cat > "${temp_dir}/long-bullet.txt" <<EOF
+New features
+
+- ${long_idea}
+EOF
+expect_fail "${temp_dir}/long-bullet.txt"
 
 printf 'Android Play notes regression tests passed.\n'

--- a/scripts/ios-release-notes-check.sh
+++ b/scripts/ios-release-notes-check.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
-# Validate that TestFlight notes are concise, actionable, and safe for non-developer testers.
+# Validate TestFlight notes: this-build window, compact or detailed, safe for testers.
+# Caps: scripts/tester-notes-limits.sh  Contract: docs/tester-notes.md
 set -euo pipefail
 
 notes_path="${1:-ios/TestFlight/WhatToTest.en-US.txt}"
-max_characters=4000
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tester-notes-limits.sh
+source "${script_dir}/tester-notes-limits.sh"
 
 fail() {
   printf 'TestFlight notes check failed: %s\n' "$1" >&2
@@ -13,12 +16,17 @@ fail() {
 [[ -f "$notes_path" ]] || fail "missing ${notes_path}"
 
 character_count="$(wc -m < "$notes_path" | tr -d '[:space:]')"
-if ((character_count > max_characters)); then
-  fail "${notes_path} is ${character_count} characters; App Store Connect allows ${max_characters}"
+if ((character_count > tester_notes_max_characters)); then
+  fail "${notes_path} is ${character_count} characters; this-build notes cap is ${tester_notes_max_characters}"
 fi
 
-# Accept a compact feature summary or the detailed three-section tester format.
-if ! awk '
+# Compact "New features" or detailed three-section form. Caps keep this-build.
+awk_status=0
+awk -v max_feat="$tester_notes_max_feature_bullets" \
+  -v max_new="$tester_notes_max_new_bullets" \
+  -v max_fix="$tester_notes_max_fix_bullets" \
+  -v max_test="$tester_notes_max_test_bullets" \
+  -v max_bullet="$tester_notes_max_bullet_characters" '
   BEGIN {
     section = 0
     new_headings = 0
@@ -29,6 +37,7 @@ if ! awk '
     fix_bullets = 0
     test_bullets = 0
     invalid = 0
+    long_bullet = 0
   }
   $0 == "New features" {
     feature_headings++
@@ -56,6 +65,8 @@ if ! awk '
   }
   /^[[:space:]]*$/ { next }
   /^- .+/ {
+    body = substr($0, 3)
+    if (length(body) > max_bullet) long_bullet = 1
     if (section == 1) new_bullets++
     else if (section == 2) fix_bullets++
     else if (section == 3) test_bullets++
@@ -64,18 +75,23 @@ if ! awk '
   }
   { invalid = 1 }
   END {
+    if (long_bullet) exit 2
     if (feature_headings > 0) {
       if (feature_headings != 1 || new_headings || fix_headings || test_headings || invalid) exit 1
-      if (new_bullets < 1 || new_bullets > 6) exit 1
+      if (new_bullets < 1 || new_bullets > max_feat) exit 1
       exit 0
     }
     if (new_headings != 1 || fix_headings != 1 || test_headings != 1 || invalid) exit 1
-    if (new_bullets < 1 || new_bullets > 6) exit 1
-    if (fix_bullets < 1 || fix_bullets > 8) exit 1
-    if (test_bullets < 1 || test_bullets > 5) exit 1
+    if (new_bullets < 1 || new_bullets > max_new) exit 1
+    if (fix_bullets < 1 || fix_bullets > max_fix) exit 1
+    if (test_bullets < 1 || test_bullets > max_test) exit 1
   }
-' "$notes_path"; then
-  fail "use 'New features' with 1-6 bullets, or 'New and changed', 'Fixes', 'What to test' with 1-6 / 1-8 / 1-5 bullets"
+' "$notes_path" || awk_status=$?
+if ((awk_status == 2)); then
+  fail "each bullet is one idea, under ${tester_notes_max_bullet_characters} characters"
+fi
+if ((awk_status != 0)); then
+  fail "use 'New features' with 1-${tester_notes_max_feature_bullets} bullets, or 'New and changed', 'Fixes', 'What to test' with 1-${tester_notes_max_new_bullets} / 1-${tester_notes_max_fix_bullets} / 1-${tester_notes_max_test_bullets} bullets"
 fi
 
 if grep -Eiq '^- (feat|fix|perf|refactor|chore|build|test|style)(\([^)]+\))?!?:' "$notes_path"; then

--- a/scripts/ios-release-notes-test.sh
+++ b/scripts/ios-release-notes-test.sh
@@ -63,11 +63,11 @@ for suffix in 'New features' 'New and changed' 'Fixes' 'What to test'; do
   expect_fail "${temp_dir}/mixed-features.txt"
 done
 
-for _ in {2..6}; do
+for _ in {2..4}; do
   printf '%s\n' '- Another visible feature.' >> "${temp_dir}/features.txt"
 done
 expect_pass "${temp_dir}/features.txt"
-printf '%s\n' '- A seventh feature exceeds the limit.' >> "${temp_dir}/features.txt"
+printf '%s\n' '- A fifth feature exceeds the this-build window.' >> "${temp_dir}/features.txt"
 expect_fail "${temp_dir}/features.txt"
 
 printf 'New features\n\n- Added a GUID migration.\n' > "${temp_dir}/feature-jargon.txt"
@@ -203,5 +203,88 @@ Fixes
 What to test
 EOF
 expect_fail "${temp_dir}/missing-action.txt"
+
+# this-build caps: 3 new / 4 fixes / 3 tests, 200 characters per bullet, 2000 file.
+cat > "${temp_dir}/four-new.txt" <<'EOF'
+New and changed
+
+- First visible change.
+- Second visible change.
+- Third visible change.
+- Fourth visible change.
+
+Fixes
+
+- Pairing no longer stalls when the camera drops off mid-search.
+
+What to test
+
+- Try the updated behavior.
+EOF
+expect_fail "${temp_dir}/four-new.txt"
+
+cat > "${temp_dir}/five-fixes.txt" <<'EOF'
+New and changed
+
+- A visible change.
+
+Fixes
+
+- First fix.
+- Second fix.
+- Third fix.
+- Fourth fix.
+- Fifth fix.
+
+What to test
+
+- Try the updated behavior.
+EOF
+expect_fail "${temp_dir}/five-fixes.txt"
+
+cat > "${temp_dir}/four-tests.txt" <<'EOF'
+New and changed
+
+- A visible change.
+
+Fixes
+
+- Pairing no longer stalls when the camera drops off mid-search.
+
+What to test
+
+- First action.
+- Second action.
+- Third action.
+- Fourth action.
+EOF
+expect_fail "${temp_dir}/four-tests.txt"
+
+long_idea="$(python3 -c 'print("A" * 201)')"
+cat > "${temp_dir}/long-bullet.txt" <<EOF
+New and changed
+
+- ${long_idea}
+
+Fixes
+
+- Pairing no longer stalls when the camera drops off mid-search.
+
+What to test
+
+- Try the updated behavior.
+EOF
+expect_fail "${temp_dir}/long-bullet.txt"
+
+{
+  printf '%s\n\n' "New and changed"
+  printf '%s\n' "- A visible change that testers have not already been asked to try."
+  printf '\n%s\n\n' "Fixes"
+  printf '%s\n' "- Pairing no longer stalls when the camera drops off mid-search."
+  printf '\n%s\n\n' "What to test"
+  printf '%s\n' "- Try the updated behavior."
+  python3 -c 'print("\n" + ("padding line for the this-build character cap.\n" * 80))'
+} > "${temp_dir}/too-long-file.txt"
+expect_fail "${temp_dir}/too-long-file.txt"
 
 printf 'TestFlight notes regression tests passed.\n'

--- a/scripts/tester-notes-limits.sh
+++ b/scripts/tester-notes-limits.sh
@@ -1,0 +1,8 @@
+# Caps for TestFlight / Play What to Test. Sourced by the check scripts.
+# Contract: docs/tester-notes.md
+tester_notes_max_characters=2000
+tester_notes_max_feature_bullets=4
+tester_notes_max_new_bullets=3
+tester_notes_max_fix_bullets=4
+tester_notes_max_test_bullets=3
+tester_notes_max_bullet_characters=200

--- a/scripts/tester-notes-window.sh
+++ b/scripts/tester-notes-window.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Print the operator-visible feat/fix window for TestFlight / Play notes.
+# Does not write notes files. Contract: docs/tester-notes.md
+set -euo pipefail
+
+range="${1:-}"
+if [[ -z "$range" ]]; then
+  if git rev-parse --verify --quiet origin/main >/dev/null; then
+    range=origin/main
+  else
+    range=main
+  fi
+fi
+
+operator_commits() {
+  local rev="$1"
+  git log --first-parent --format='%h %s' -n 80 "$rev" \
+    | grep -E '^[0-9a-f]+ (feat|fix)(\([^)]+\))?!?:' \
+    | head -n 8 || true
+}
+
+printf 'this-build window — keep about four items this platform can see.\n' >&2
+printf 'This PR leads. Skip build/ci/docs/chore and the other shell.\n' >&2
+printf 'Replace WhatToTest; CHANGELOG.md is the cumulative record.\n\n' >&2
+
+merge_base="$(git merge-base HEAD "$range" 2>/dev/null || true)"
+if [[ -n "$merge_base" && "$(git rev-parse HEAD)" != "$(git rev-parse "$range")" ]]; then
+  branch_window="$(operator_commits "${merge_base}..HEAD")"
+  if [[ -n "$branch_window" ]]; then
+    printf 'This branch:\n'
+    printf '%s\n' "$branch_window"
+    printf '\n'
+  fi
+fi
+
+printf 'Recent on %s (newest first):\n' "$range"
+main_window="$(operator_commits "$range")"
+if [[ -z "$main_window" ]]; then
+  printf '(none)\n' >&2
+  exit 0
+fi
+printf '%s\n' "$main_window"


### PR DESCRIPTION
## What & why

TestFlight and Play What to Test had been accumulating into a product recap. Testers already saw those items. This PR makes notes a **this-build window**: this PR plus up to three other newest operator-visible `feat:` / `fix:` items this platform can see. `CHANGELOG.md` stays the cumulative record.

`just tester-notes-window` prints that list. Checkers cap **New features** at 1–4 (the #320 summary form) or **New and changed** / **Fixes** / **What to test** at 1–3 / 1–4 / 1–3, 200 characters per bullet, 2,000 for the file. CI no longer treats notes-check scripts as a TestFlight/Play archive trigger.

Current #328 portrait-FORMAT notes are unchanged — they already are this-build.

## Tester notes

No app behavior change. Existing WhatToTest files stay as #328 left them.

## Checklist

- [x] `just check` passes.
- [x] Native production changes: not applicable (docs/scripts/CI only).
- [x] Commits follow Conventional Commits.
- [x] No captures, Wi-Fi passwords, unofficial LUT dumps, signing material, or other secrets.
- [x] Docs/CHANGELOG updated if behavior or setup changed. Public handbook pages updated when protocol, app, or setup visitors read has changed.
- [x] TestFlight- or Play-triggering changes replace WhatToTest with the this-build window (`docs/tester-notes.md`).
- [ ] iOS release PRs: bump `MARKETING_VERSION` in `ios/Config/Version.xcconfig` when starting a new version train.