### PR TITLE
docs: explain Watch companion signing in Xcode Cloud

### DIFF
--- a/docs/testflight-ci.md
+++ b/docs/testflight-ci.md
@@ -28,6 +28,31 @@ One-time App Store Connect / Xcode setup is the wizard:
 That walkthrough reuses the App Store Connect record for `com.opencapture.openpocketcine`,
 connects this GitHub repo, and defines the `main` Archive workflow.
 
+## Watch companion signing
+
+Register both explicit bundle IDs in **Certificates, Identifiers & Profiles** on
+the Apple Developer team used by the workflow:
+
+- iPhone app: `com.opencapture.openpocketcine`
+- Watch companion: `com.opencapture.openpocketcine.watch`
+
+Xcode Cloud cannot register a new Watch bundle ID during export. A successful
+simulator build or unsigned archive does not prove this prerequisite is met.
+Local Xcode automatic signing can register the identifier and create its
+provisioning profile when the signed-in account has permission. See Apple's
+[Xcode Cloud setup guidance](https://developer.apple.com/documentation/xcode/configuring-your-first-xcode-cloud-workflow).
+
+If all distribution exports fail after adding a target, download the build's
+**Logs** artifact from Xcode Cloud → Archive → **Artifacts**. Read
+`app-store-export-archive-logs/xcodebuild-export-archive.log`; the summary's exit
+code 70 and `IDEDistribution.critical.log` may omit the actionable provisioning
+error. For `Automatic signing cannot register bundle identifier` followed by
+`No profiles ... were found`, verify the named identifier is registered on the
+workflow's team; register it if missing. If it already exists, check that the
+target and workflow use the same team and that Cloud can access the required
+provisioning profiles, then rebuild. Keep downloaded logs and provisioning
+profiles outside git.
+
 ## After the workflow exists
 
 - **Merges to `main`** that touch `Sources/`, `Tests/`, `ios/`, `Package.swift`, `scripts/`, or
@@ -101,6 +126,7 @@ prompt (the app only uses Apple ATS/HTTPS).
 | Symptom | Likely cause |
 | --- | --- |
 | Cloud build cannot open `OpenPocketCine.xcodeproj` | `ci_post_clone.sh` did not run or `xcodegen` failed |
+| Export cannot register the Watch bundle ID and finds no profiles | Check identifier registration, team alignment and provisioning access; see [Watch companion signing](#watch-companion-signing) |
 | Frame.io login missing in the build | Add the three `FRAMEIO_*` environment variables on the workflow |
 | “Build number already used” | Raise the workflow's next build number above the App Store Connect high-water mark |
 | Archive succeeds but testers see nothing | Wait for processing; first external build of a version sits in TestFlight App Review |

--- a/handbook/src/content/docs/apps/ios.md
+++ b/handbook/src/content/docs/apps/ios.md
@@ -185,6 +185,12 @@ change `Sources/`, `ios/`, or `Package.swift` replace
 `ios/TestFlight/WhatToTest.en-US.txt` with the this-build window. See
 [`docs/tester-notes.md`](https://github.com/erik-sutton95/OpenPocketCine/blob/main/docs/tester-notes.md).
 
+Maintainers using Xcode Cloud must register both the iPhone bundle ID and
+`com.opencapture.openpocketcine.watch` on their Apple Developer team before
+exporting an archive with the Watch companion. Cloud cannot register the Watch
+identifier during export. Setup and export-log troubleshooting:
+[Watch companion signing](https://github.com/erik-sutton95/OpenPocketCine/blob/main/docs/testflight-ci.md#watch-companion-signing).
+
 If pairing or live view fails: Connection setup **Share Diagnostics**, or
 Operator Setup → System → **Share Diagnostics**, or take a screenshot for
 TestFlight and paste the copied report into the feedback. The report has no


### PR DESCRIPTION
## What & why

Xcode Cloud builds 102 and 103 compiled the iOS archive but failed every distribution export because automatic signing could not register `com.opencapture.openpocketcine.watch` and found no profiles for it. Document the Watch identifier prerequisite, team/profile checks, and the exact artifact log that exposes the error behind exit code 70. Link this setup guidance from the public iOS handbook.

A local Release archive and App Store export succeeded with the existing app configuration and generated the Watch App Store provisioning profile. Cloud build 104 then passed Archive - iOS on the identical application commit (`f4492d6`), confirming the account-side repair. No app code or signing settings change in this PR.

## Tester notes

Documentation only; no new tester-facing behavior or version train. Keep the cumulative build 63 → 102 notes, including CineStop, IRE and EL Zone, unchanged.

## Validation

- `just check` passed (784 core tests, repository quality gates).
- `just handbook-build` passed.
- Local signed Release archive and App Store export passed with the Watch companion embedded.
- Fresh-context review completed; troubleshooting wording includes team/profile access as well as missing registration.
- Xcode Cloud build 104 Archive - iOS passed on the original failing commit, with 17 compiler warnings and zero export errors.

## Checklist

- [x] `just check` passes.
- [x] Native production changes: none; local archive/export verified during diagnosis.
- [x] Commits follow Conventional Commits.
- [x] No captures, credentials, signing material or private build logs committed.
- [x] Engineering setup docs and public handbook updated.
- [x] Tester notes unchanged: documentation-only follow-up.
- [x] No new marketing version train.
