### PR TITLE
docs: restore open-beta TestFlight notes from build 105

### DIFF
--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,18 +1,40 @@
+Since open beta build 63
+
 New and changed
 
-- Recovery shows the current connection stage and keeps Retry and Operator menu available. Share Diagnostics includes more detail about uneven live video.
-- Gimbal controls use Mode, Speed and Ramp tabs. Drag and resize scopes, LIGHTS and ND; Your cameras shows progress and Cancel.
-- Apple Watch provides live preview, timecode, storage, camera battery, record and shutter controls through the paired iPhone.
+- Direction Lock holds the camera pointing in one direction as you rotate its body. Select another mode to release it.
+- Gimbal controls uses Mode, Speed, and Ramp tabs, with Motion Control in Gimbal tools.
+- Experimental Motion Control adds timed A-to-B or A-to-B-to-C moves, smoothing, a countdown, and Pause, Resume and Stop.
+- Experimental AirPods head tracking follows calibrated head direction more directly. Manual control wins; changing gimbal mode turns tracking off.
+- Drag scopes, LIGHTS and ND directly; drag a corner to resize. Panels fit under bars and the joystick, with equal left/right spacing.
+- ND assist suggests a filter strength to balance exposure, with Stops, ND factor and optical-density units.
+- New false-color choices include CineStop, six-zone IRE and EL Zone, with matching reference legends.
+- Experimental Multiview monitors Osmo cameras on shared Wi-Fi, with saved stages, grid or Center stage, per-camera looks and group recording.
+- Share this feed lets other iPhones and iPads on the same camera Wi-Fi watch with local assists, request camera controls and reconnect after interruptions.
+- Apple Watch adds live preview, timecode, storage, camera battery, record and shutter controls. The paired iPhone stays connected to the camera.
+- Convert log on Share matches D-Log and D-Log2 clips during export, separately from Bake LUT. Originals stay untouched; D-Log M conversion is excluded.
+- Your cameras shows joining progress and Cancel on the selected camera row. Watch a feed is the eye button beside Multiview.
+- Manual joystick and gamepad input takes over from programmed gimbal moves.
+- Share Diagnostics from pairing or Operator Setup > System to report connection and playback problems.
 
 Fixes
 
-- App return checks camera Wi-Fi and reconnects when needed. Recovery waits for a new picture and stops automatic retries after a bounded interval.
-- Live rendering avoids waiting for a drawable on the main thread. Old decoder results cannot dismiss a new recovery; gimbal control waits for the live picture.
-- Reconnect starts a fresh camera session. AirPods startup offers clearer permission and retry guidance; scopes can sit beneath Head Lock.
-- Pocket 3 keeps portrait 3K selected while format options load and frame rate changes.
+- Zebra Highlight detects the hottest color channel and defaults to 99 IRE. Zebra option fields stay above the keyboard, with Done to dismiss it.
+- Expanded Pocket 3 support: more reliable live view and reconnects, correct camera settings, and access to newly recorded clips.
+- Pocket 3 COLOR correctly maps Normal, HDR/HLG and D-Log M instead of switching to the wrong profile.
+- FORMAT shows camera-reported sizes, frame rates and aspect ratios. A selected pair stays visible until the camera confirms it.
+- Pocket 3 FORMAT includes normal-video 2.7K and portrait choices when its format list is empty. Vertical 3K stays selected while options load and frame rate changes.
+- Pocket 3 clips can be listed and opened after a take, including recordings stored on its memory card.
+- In Normal color, Pocket 3 and Pocket 4 Auto ISO ranges start at 50, matching the camera; Pocket 4 Pro starts at 100.
+- Nano COLOR now matches Normal 8-bit, Normal 10-bit and D-Log M. Live-view handling also copes better with larger Nano frames.
+- D-Log M scopes use their own signal scale. Scene-stop readings are marked as estimates; sensor clipping limits are not calibrated.
+- Renamed camera Wi-Fi networks use the current name. Failed joins clear stale connection details, and setup warns when a VPN or ad blocker may prevent live view.
+- Live-view stability improves when zooming, changing settings, toggling LUT 50/50, or returning from clips. Recovery keeps the last picture visible.
+- False color stays visible while Auto ISO changes exposure. Video and monitoring overlays stay aligned through rotation and Fit/Fill changes.
 
 What to test
 
-- On Pocket 4 Pro, compare static shots and slow pans with LUT/scopes off and on. Try LUT 50/50 and rotation; share diagnostics with the time of any stutter.
-- Try joystick and gimbal modes after first picture, then AirPods calibration and scopes beneath Head Lock. Leave the app for 15 and 60 seconds; check recovery after a camera Wi-Fi change.
-- Check Retry, Cancel and reconnect after a camera power cycle. Try Watch preview and recording. AirPods and Motion Control remain experimental.
+- On Pocket 3, check live view, Normal/HDR/D-Log M, 2.7K and portrait 3K, recording, clip playback and reconnecting.
+- Try Direction Lock and a Motion Control move, then take over manually. Drag and resize scopes to each edge in portrait and landscape.
+- Compare false-color scales and ND units. Keep the picture live while changing settings, zooming and reopening clips; share diagnostics if it freezes.
+- Try Multiview, sharing to another device, Apple Watch controls and Convert log export. Motion Control, Multiview and AirPods head tracking remain experimental.


### PR DESCRIPTION
## What & why

TestFlight build 106 already processed with the short this-build notes from #336. Apple stamps What to Test at archive time; this repo has no App Store Connect API to patch 106.

Restore the cumulative **Since open beta build 63** copy from build 105 (`#332`) so the next Xcode Cloud archive (107) shows testers the same notes.

## Tester notes

This PR *is* the notes restore. `ios/TestFlight/WhatToTest.en-US.txt` matches build 105.

## Checklist

- [x] `just check` passes.
- [x] Native production changes: not applicable (TestFlight copy only).
- [x] Commits follow Conventional Commits.
- [x] No captures, Wi-Fi passwords, unofficial LUT dumps, signing material, or other secrets.
- [x] Docs/CHANGELOG updated if behavior or setup changed.
- [x] TestFlight- or Play-triggering changes replace WhatToTest with the this-build window (`docs/tester-notes.md`). Named open-beta baseline (`Since open beta build 63`).
- [ ] iOS release PRs: bump `MARKETING_VERSION` in `ios/Config/Version.xcconfig` when starting a new version train.